### PR TITLE
Added logic to collapse unneeded maneuvers - the maneuvers had only prefix and/or suffix directional differences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ test/maneuversbuilder
 test/narrativebuilder
 test/enhancedtrippath
 test/sign
+test/streetname
+test/streetnames
 test/*.log
 test/*.trs
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -85,7 +85,9 @@ check_PROGRAMS = \
 	test/maneuversbuilder \
 	test/narrativebuilder \
 	test/enhancedtrippath \
-	test/sign 
+	test/sign \
+	test/streetname \
+	test/streetnames 
 test_maneuversbuilder_SOURCES = test/maneuversbuilder.cc test/test.cc
 test_maneuversbuilder_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 test_maneuversbuilder_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_odin.la
@@ -98,6 +100,12 @@ test_enhancedtrippath_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ l
 test_sign_SOURCES = test/sign.cc test/test.cc
 test_sign_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 test_sign_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_odin.la
+test_streetname_SOURCES = test/streetname.cc test/test.cc
+test_streetname_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
+test_streetname_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_odin.la
+test_streetnames_SOURCES = test/streetnames.cc test/test.cc
+test_streetnames_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
+test_streetnames_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_odin.la
 
 TESTS = $(check_PROGRAMS)
 TEST_EXTENSIONS = .sh

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -95,7 +95,7 @@ TripDirections DirectionsBuilder::PopulateTripDirections(
     trip_maneuver->set_type(maneuver.type());
     trip_maneuver->set_text_instruction(maneuver.instruction());
     for (const auto& street_name : maneuver.street_names()) {
-      trip_maneuver->add_street_name(street_name.name());
+      trip_maneuver->add_street_name(street_name.value());
     }
     trip_maneuver->set_length(maneuver.distance());
     trip_maneuver->set_time(maneuver.time());

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -79,10 +79,10 @@ std::list<Maneuver> ManeuversBuilder::Produce() {
     uint32_t left_count;
     uint32_t left_similar_count;
     node->CalculateRightLeftIntersectingEdgeCounts(prev_edge->end_heading(),
-                                                   right_count,
-                                                   right_similar_count,
-                                                   left_count,
-                                                   left_similar_count);
+        right_count,
+        right_similar_count,
+        left_count,
+        left_similar_count);
     LOG_TRACE(std::string("    right_count=") + std::to_string(right_count)
         + std::string("    left_count=") + std::to_string(left_count));
     LOG_TRACE(std::string("    right_similar_count=") + std::to_string(right_similar_count)
@@ -318,8 +318,7 @@ void ManeuversBuilder::SetManeuverType(Maneuver& maneuver, int node_index) {
         // TODO: determine how to handle, for now set to right
         maneuver.set_type(TripDirections_Maneuver_Type_kExitRight);
       }
-    }
-    LOG_TRACE("EXIT");
+    } LOG_TRACE("EXIT");
   }
   // Process on ramp
   else if (maneuver.ramp() && !prev_edge->IsHighway()) {
@@ -346,8 +345,7 @@ void ManeuversBuilder::SetManeuverType(Maneuver& maneuver, int node_index) {
         // TODO: determine how to handle, for now set to right
         maneuver.set_type(TripDirections_Maneuver_Type_kRampRight);
       }
-    }
-    LOG_TRACE("RAMP");
+    } LOG_TRACE("RAMP");
   }
   // Process merge
   else if (curr_edge->IsHighway() && prev_edge->ramp()) {
@@ -488,11 +486,11 @@ bool ManeuversBuilder::CanManeuverIncludePrevEdge(Maneuver& maneuver,
     return true;
   }
 
-  // Process common names
-  StreetNames common_street_names = maneuver.street_names()
-      .FindCommonStreetNames(prev_edge_names);
-  if (!common_street_names.empty()) {
-    maneuver.set_street_names(std::move(common_street_names));
+  // Process common base names
+  StreetNames common_base_names = prev_edge_names.FindCommonBaseNames(
+      maneuver.street_names());
+  if (!common_base_names.empty()) {
+    maneuver.set_street_names(std::move(common_base_names));
     return true;
   }
 

--- a/src/odin/streetname.cc
+++ b/src/odin/streetname.cc
@@ -2,8 +2,16 @@
 
 #include "odin/streetname.h"
 
+#include <boost/algorithm/string/predicate.hpp>
+
 namespace valhalla {
 namespace odin {
+
+// TODO - locale
+const std::vector<std::string> StreetName::pre_dirs_ { "North ", "East ",
+    "South ", "West ", "Northeast ", "Southeast ", "Southwest ", "Northwest " };
+const std::vector<std::string> StreetName::post_dirs_ { " North", " East",
+    " South", " West", " Northeast", " Southeast", " Southwest", " Northwest" };
 
 StreetName::StreetName(const std::string& value)
     : value_(value) {
@@ -15,6 +23,42 @@ const std::string& StreetName::value() const {
 
 bool StreetName::operator ==(const StreetName& rhs) const {
   return (value_ == rhs.value_);
+}
+
+bool StreetName::StartsWith(const std::string& prefix) const {
+  return boost::algorithm::starts_with(value_, prefix);
+}
+
+bool StreetName::EndsWith(const std::string& suffix) const {
+  return boost::algorithm::ends_with(value_, suffix);
+}
+
+std::string StreetName::GetPreDir() const {
+  for (const auto& pre_dir : StreetName::pre_dirs_) {
+    if (StartsWith(pre_dir))
+      return pre_dir;
+  }
+  return "";
+}
+
+std::string StreetName::GetPostDir() const {
+  for (const auto& post_dir : StreetName::post_dirs_) {
+    if (EndsWith(post_dir))
+      return post_dir;
+  }
+  return "";
+}
+
+std::string StreetName::GetBaseName() const {
+  std::string pre_dir = GetPreDir();
+  std::string post_dir = GetPostDir();
+
+  return value_.substr(pre_dir.size(),
+                       (value_.size() - pre_dir.size() - post_dir.size()));
+}
+
+bool StreetName::HasSameBaseName(const StreetName& rhs) const {
+  return (GetBaseName() == rhs.GetBaseName());
 }
 
 }

--- a/src/odin/streetname.cc
+++ b/src/odin/streetname.cc
@@ -5,16 +5,16 @@
 namespace valhalla {
 namespace odin {
 
-StreetName::StreetName(const std::string& name)
-    : name_(name) {
+StreetName::StreetName(const std::string& value)
+    : value_(value) {
 }
 
-const std::string& StreetName::name() const {
-  return name_;
+const std::string& StreetName::value() const {
+  return value_;
 }
 
 bool StreetName::operator ==(const StreetName& rhs) const {
-  return (name_ == rhs.name_);
+  return (value_ == rhs.value_);
 }
 
 }

--- a/src/odin/streetname.cc
+++ b/src/odin/streetname.cc
@@ -12,6 +12,8 @@ const std::vector<std::string> StreetName::pre_dirs_ { "North ", "East ",
     "South ", "West ", "Northeast ", "Southeast ", "Southwest ", "Northwest " };
 const std::vector<std::string> StreetName::post_dirs_ { " North", " East",
     " South", " West", " Northeast", " Southeast", " Southwest", " Northwest" };
+const std::vector<std::string> StreetName::post_cardinal_dirs_ { " North",
+    " East", " South", " West" };
 
 StreetName::StreetName(const std::string& value)
     : value_(value) {
@@ -45,6 +47,14 @@ std::string StreetName::GetPostDir() const {
   for (const auto& post_dir : StreetName::post_dirs_) {
     if (EndsWith(post_dir))
       return post_dir;
+  }
+  return "";
+}
+
+std::string StreetName::GetPostCardinalDir() const {
+  for (const auto& post_cardinal_dir : StreetName::post_cardinal_dirs_) {
+    if (EndsWith(post_cardinal_dir))
+      return post_cardinal_dir;
   }
   return "";
 }

--- a/src/odin/streetnames.cc
+++ b/src/odin/streetnames.cc
@@ -13,7 +13,7 @@ StreetNames::StreetNames(
     const ::google::protobuf::RepeatedPtrField<::std::string>& names)
     : std::list<StreetName>() {
   for (const auto& name : names) {
-    this->push_back(StreetName(name));
+    this->emplace_back(name);
   }
 
 }
@@ -26,7 +26,7 @@ std::string StreetNames::ToString() const {
     if (!name_string.empty()) {
       name_string += "/";
     }
-    name_string += street_name.name();
+    name_string += street_name.value();
   }
   return name_string;
 }

--- a/src/odin/streetnames.cc
+++ b/src/odin/streetnames.cc
@@ -31,7 +31,8 @@ std::string StreetNames::ToString() const {
   return name_string;
 }
 
-StreetNames StreetNames::FindCommonStreetNames(StreetNames other_street_names) const {
+StreetNames StreetNames::FindCommonStreetNames(
+    StreetNames other_street_names) const {
   StreetNames common_street_names;
   for (const auto& street_name : *this) {
     for (const auto& other_street_name : other_street_names) {
@@ -43,6 +44,29 @@ StreetNames StreetNames::FindCommonStreetNames(StreetNames other_street_names) c
   }
 
   return common_street_names;
+}
+
+StreetNames StreetNames::FindCommonBaseNames(
+    StreetNames other_street_names) const {
+  StreetNames common_base_names;
+  for (const auto& street_name : *this) {
+    for (const auto& other_street_name : other_street_names) {
+      if (street_name.HasSameBaseName(other_street_name)) {
+        // Use the name with the cardinal directional suffix
+        // thus, 'US 30 West' will be used instead of 'US 30'
+        if (!street_name.GetPostCardinalDir().empty())
+          common_base_names.push_back(street_name);
+        else if (!other_street_name.GetPostCardinalDir().empty())
+          common_base_names.push_back(other_street_name);
+        // Use street_name by default
+        else
+          common_base_names.push_back(street_name);
+        break;
+      }
+    }
+  }
+
+  return common_base_names;
 }
 
 }

--- a/test/sign.cc
+++ b/test/sign.cc
@@ -31,10 +31,10 @@ void TestCtor() {
   // Exit branch
   TryCtor("I 81 South");
 
-  // Exit number
+  // Exit toward
   TryCtor("Carlisle");
 
-  // Exit number
+  // Exit name
   TryCtor("Harrisburg East");
 }
 

--- a/test/streetname.cc
+++ b/test/streetname.cc
@@ -99,6 +99,21 @@ void TestGetPostDir() {
   TryGetPostDir(StreetName("Main Street"), "");
 }
 
+void TryGetPostCardinalDir(const StreetName& street_name,
+                           const std::string& post_dir) {
+  if (post_dir != street_name.GetPostCardinalDir())
+    throw std::runtime_error(
+        street_name.value() + ": Incorrect GetPostCardinalDir");
+}
+
+void TestGetPostCardinalDir() {
+  TryGetPostCardinalDir(StreetName("US 220 North"), " North");
+  TryGetPostCardinalDir(StreetName("US 22 East"), " East");
+  TryGetPostCardinalDir(StreetName("I 81 South"), " South");
+  TryGetPostCardinalDir(StreetName("PA 283 West"), " West");
+  TryGetPostCardinalDir(StreetName("Main Street"), "");
+}
+
 void TryGetBaseName(const StreetName& street_name,
                     const std::string& base_name) {
   if (base_name != street_name.GetBaseName())
@@ -201,6 +216,9 @@ int main() {
 
   // GetPostDir
   suite.test(TEST_CASE(TestGetPostDir));
+
+  // GetPostCardinalDir
+  suite.test(TEST_CASE(TestGetPostCardinalDir));
 
   // GetBaseName
   suite.test(TEST_CASE(TestGetBaseName));

--- a/test/streetname.cc
+++ b/test/streetname.cc
@@ -51,7 +51,7 @@ void TestEquals() {
 
 void TryStartsWith(const StreetName& street_name, const std::string& prefix) {
   if (!street_name.StartsWith(prefix))
-    throw std::runtime_error("Incorrect StartsWith");
+    throw std::runtime_error(street_name.value() + ": Incorrect StartsWith");
 }
 
 void TestStartsWith() {
@@ -61,7 +61,7 @@ void TestStartsWith() {
 
 void TryEndsWith(const StreetName& street_name, const std::string& suffix) {
   if (!street_name.EndsWith(suffix))
-    throw std::runtime_error("Incorrect EndsWith");
+    throw std::runtime_error(street_name.value() + ": Incorrect EndsWith");
 }
 
 void TestEndsWith() {
@@ -71,7 +71,7 @@ void TestEndsWith() {
 
 void TryGetPreDir(const StreetName& street_name, const std::string& pre_dir) {
   if (pre_dir != street_name.GetPreDir())
-    throw std::runtime_error("Incorrect GetPreDir");
+    throw std::runtime_error(street_name.value() + ": Incorrect GetPreDir");
 }
 
 void TestGetPreDir() {
@@ -84,7 +84,7 @@ void TestGetPreDir() {
 
 void TryGetPostDir(const StreetName& street_name, const std::string& post_dir) {
   if (post_dir != street_name.GetPostDir())
-    throw std::runtime_error("Incorrect GetPostDir");
+    throw std::runtime_error(street_name.value() + ": Incorrect GetPostDir");
 }
 
 void TestGetPostDir() {
@@ -102,7 +102,7 @@ void TestGetPostDir() {
 void TryGetBaseName(const StreetName& street_name,
                     const std::string& base_name) {
   if (base_name != street_name.GetBaseName())
-    throw std::runtime_error("Incorrect GetBaseName");
+    throw std::runtime_error(street_name.value() + ": Incorrect GetBaseName");
 }
 
 void TestGetBaseName() {
@@ -130,8 +130,10 @@ void TestGetBaseName() {
 }
 
 void TryHasSameBaseName(const StreetName& street_name, const StreetName& rhs) {
-  if (!street_name.HasSameBaseName(rhs))
-    throw std::runtime_error("Incorrect HasSameBaseName");
+  if (!street_name.HasSameBaseName(rhs)) {
+    throw std::runtime_error(
+        street_name.value() + ": Incorrect HasSameBaseName");
+  }
 }
 
 void TestHasSameBaseName() {

--- a/test/streetname.cc
+++ b/test/streetname.cc
@@ -32,13 +32,179 @@ void TestCtor() {
 
 }
 
+void TryEquals(const std::string& text) {
+  StreetName lhs(text);
+  StreetName rhs(text);
+
+  if (!(lhs == rhs))
+    throw std::runtime_error("Incorrect equals return");
+
 }
 
+void TestEquals() {
+  TryEquals("Main Street");
+  TryEquals("PA 743");
+  TryEquals("US 220 Business");
+  TryEquals("I 81 South");
+
+}
+
+void TryStartsWith(const StreetName& street_name, const std::string& prefix) {
+  if (!street_name.StartsWith(prefix))
+    throw std::runtime_error("Incorrect StartsWith");
+}
+
+void TestStartsWith() {
+  TryStartsWith(StreetName("I 81 South"), "I ");
+  TryStartsWith(StreetName("North Main Street"), "North");
+}
+
+void TryEndsWith(const StreetName& street_name, const std::string& suffix) {
+  if (!street_name.EndsWith(suffix))
+    throw std::runtime_error("Incorrect EndsWith");
+}
+
+void TestEndsWith() {
+  TryEndsWith(StreetName("I 81 South"), "South");
+  TryEndsWith(StreetName("Main Street"), "Street");
+}
+
+void TryGetPreDir(const StreetName& street_name, const std::string& pre_dir) {
+  if (pre_dir != street_name.GetPreDir())
+    throw std::runtime_error("Incorrect GetPreDir");
+}
+
+void TestGetPreDir() {
+  TryGetPreDir(StreetName("North Main Street"), "North ");
+  TryGetPreDir(StreetName("East Chestnut Avenue"), "East ");
+  TryGetPreDir(StreetName("South Main Street"), "South ");
+  TryGetPreDir(StreetName("West 26th Street"), "West ");
+  TryGetPreDir(StreetName("Main Street"), "");
+}
+
+void TryGetPostDir(const StreetName& street_name, const std::string& post_dir) {
+  if (post_dir != street_name.GetPostDir())
+    throw std::runtime_error("Incorrect GetPostDir");
+}
+
+void TestGetPostDir() {
+  TryGetPostDir(StreetName("US 220 North"), " North");
+  TryGetPostDir(StreetName("US 22 East"), " East");
+  TryGetPostDir(StreetName("I 81 South"), " South");
+  TryGetPostDir(StreetName("PA 283 West"), " West");
+  TryGetPostDir(StreetName("Constitution Avenue Northeast"), " Northeast");
+  TryGetPostDir(StreetName("Constitution Avenue Northwest"), " Northwest");
+  TryGetPostDir(StreetName("Independence Avenue Southeast"), " Southeast");
+  TryGetPostDir(StreetName("Independence Avenue Southwest"), " Southwest");
+  TryGetPostDir(StreetName("Main Street"), "");
+}
+
+void TryGetBaseName(const StreetName& street_name,
+                    const std::string& base_name) {
+  if (base_name != street_name.GetBaseName())
+    throw std::runtime_error("Incorrect GetBaseName");
+}
+
+void TestGetBaseName() {
+  TryGetBaseName(StreetName("North Main Street"), "Main Street");
+  TryGetBaseName(StreetName("East Chestnut Avenue"), "Chestnut Avenue");
+  TryGetBaseName(StreetName("South Main Street"), "Main Street");
+  TryGetBaseName(StreetName("West 26th Street"), "26th Street");
+  TryGetBaseName(StreetName("US 220 North"), "US 220");
+  TryGetBaseName(StreetName("US 22 East"), "US 22");
+  TryGetBaseName(StreetName("I 81 South"), "I 81");
+  TryGetBaseName(StreetName("PA 283 West"), "PA 283");
+  TryGetBaseName(StreetName("Constitution Avenue Northeast"),
+                 "Constitution Avenue");
+  TryGetBaseName(StreetName("Constitution Avenue Northwest"),
+                 "Constitution Avenue");
+  TryGetBaseName(StreetName("Independence Avenue Southeast"),
+                 "Independence Avenue");
+  TryGetBaseName(StreetName("Independence Avenue Southwest"),
+                 "Independence Avenue");
+  TryGetBaseName(StreetName("North South Street Northwest"), "South Street");
+  TryGetBaseName(StreetName("East North Avenue Southwest"), "North Avenue");
+  TryGetBaseName(StreetName("Main Street"), "Main Street");
+  TryGetBaseName(StreetName("Broadway"), "Broadway");
+  TryGetBaseName(StreetName(""), "");
+}
+
+void TryHasSameBaseName(const StreetName& street_name, const StreetName& rhs) {
+  if (!street_name.HasSameBaseName(rhs))
+    throw std::runtime_error("Incorrect HasSameBaseName");
+}
+
+void TestHasSameBaseName() {
+  TryHasSameBaseName(StreetName("North Main Street"),
+                     StreetName("Main Street"));
+  TryHasSameBaseName(StreetName("East Chestnut Avenue"),
+                     StreetName("Chestnut Avenue"));
+  TryHasSameBaseName(StreetName("South Main Street"),
+                     StreetName("Main Street"));
+  TryHasSameBaseName(StreetName("West 26th Street"),
+                     StreetName("East 26th Street"));
+  TryHasSameBaseName(StreetName("I 695 West"), StreetName("I 695 South"));
+  TryHasSameBaseName(StreetName("US 220 North"), StreetName("US 220"));
+  TryHasSameBaseName(StreetName("US 22 East"), StreetName("US 22"));
+  TryHasSameBaseName(StreetName("I 81 South"), StreetName("I 81"));
+  TryHasSameBaseName(StreetName("PA 283 West"), StreetName("PA 283"));
+  TryHasSameBaseName(StreetName("Constitution Avenue Northeast"),
+                     StreetName("Constitution Avenue"));
+  TryHasSameBaseName(StreetName("Constitution Avenue Northwest"),
+                     StreetName("Constitution Avenue"));
+  TryHasSameBaseName(StreetName("Constitution Avenue Northwest"),
+                     StreetName("Constitution Avenue Northeast"));
+  TryHasSameBaseName(StreetName("Independence Avenue Southeast"),
+                     StreetName("Independence Avenue"));
+  TryHasSameBaseName(StreetName("Independence Avenue Southwest"),
+                     StreetName("Independence Avenue"));
+  TryHasSameBaseName(StreetName("Independence Avenue Southwest"),
+                     StreetName("Independence Avenue Southeast"));
+  TryHasSameBaseName(StreetName("Main Street"), StreetName("Main Street"));
+  TryHasSameBaseName(StreetName("Broadway"), StreetName("Broadway"));
+  TryHasSameBaseName(StreetName(""), StreetName(""));
+}
+
+}
+// Test cases
+////////////////////////////////////////////////
+// PRE
+// East Chestnut Avenue and Chestnut Avenue
+// West 26th Street and East 26th Street
+////////////////////////////////////////////////
+// POST
+// US 30 and US 30 West
+// I 695 West and I 695 South
+// Constitution Avenue Northeast and Constitution Avenue Northwest
+////////////////////////////////////////////////
+// PRE and POST
+//
 int main() {
   test::suite suite("streetname");
 
   // Constructor
   suite.test(TEST_CASE(TestCtor));
+
+  // Equals
+  suite.test(TEST_CASE(TestEquals));
+
+  // StartsWith
+  suite.test(TEST_CASE(TestStartsWith));
+
+  // EndsWith
+  suite.test(TEST_CASE(TestEndsWith));
+
+  // GetPreDir
+  suite.test(TEST_CASE(TestGetPreDir));
+
+  // GetPostDir
+  suite.test(TEST_CASE(TestGetPostDir));
+
+  // GetBaseName
+  suite.test(TEST_CASE(TestGetBaseName));
+
+  // HasSameBaseName
+  suite.test(TEST_CASE(TestHasSameBaseName));
 
   return suite.tear_down();
 }

--- a/test/streetname.cc
+++ b/test/streetname.cc
@@ -1,0 +1,44 @@
+#include "test.h"
+#include "valhalla/odin/streetname.h"
+
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+using namespace valhalla::odin;
+
+namespace {
+
+void TryCtor(const std::string& text) {
+  StreetName street_name(text);
+
+  if (text != street_name.value())
+    throw std::runtime_error("Incorrect street name text");
+
+}
+
+void TestCtor() {
+  // Street name
+  TryCtor("Main Street");
+
+  // Ref
+  TryCtor("PA 743");
+
+  // Ref with post modifier
+  TryCtor("US 220 Business");
+
+  // Ref with directional
+  TryCtor("I 81 South");
+
+}
+
+}
+
+int main() {
+  test::suite suite("streetname");
+
+  // Constructor
+  suite.test(TEST_CASE(TestCtor));
+
+  return suite.tear_down();
+}

--- a/test/streetnames.cc
+++ b/test/streetnames.cc
@@ -1,0 +1,78 @@
+#include "test.h"
+#include "valhalla/odin/streetname.h"
+#include "valhalla/odin/streetnames.h"
+
+#include <google/protobuf/repeated_field.h>
+
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+using namespace valhalla::odin;
+
+namespace {
+
+void TryListCtor(const std::vector<::std::string>& names) {
+  ::google::protobuf::RepeatedPtrField<::std::string> name_list;
+  for (const auto& name : names) {
+    name_list.Add()->assign(name);
+  }
+  StreetNames street_names(name_list);
+
+  int x = 0;
+  for (const auto& street_name : street_names) {
+    if (name_list.Get(x++) != street_name.value())
+      throw std::runtime_error("Incorrect street name value");
+  }
+
+}
+
+void TestListCtor() {
+  TryListCtor( { "Main Street" });
+  TryListCtor( { "Hershey Road", "PA 743 North" });
+}
+
+StreetNames GetStreetNames(const std::vector<std::string>& names) {
+  StreetNames street_names;
+  for (const auto& name : names) {
+    street_names.emplace_back(name);
+  }
+  return street_names;
+}
+void TryFindCommonStreetNames(const StreetNames& lhs, const StreetNames& rhs,
+                              const StreetNames& expected) {
+  StreetNames computed = lhs.FindCommonStreetNames(rhs);
+  if (computed != expected) {
+    throw std::runtime_error(
+        "Incorrect street names returned from FindCommonStreetNames");
+  }
+}
+
+void TestFindCommonStreetNames() {
+  TryFindCommonStreetNames(GetStreetNames( { "Hershey Road", "PA 743 North" }),
+                           GetStreetNames( { "Fishburn Road", "PA 743 North" }),
+                           GetStreetNames( { "PA 743 North" }));
+
+  TryFindCommonStreetNames(GetStreetNames( { "Hershey Road", "PA 743 North" }),
+                           GetStreetNames( { "Fishburn Road", "PA 743" }),
+                           GetStreetNames( { }));
+
+  TryFindCommonStreetNames(GetStreetNames( { "Capital Beltway", "I 95 South", "I 495 South" }),
+                           GetStreetNames( { "I 95 South" }),
+                           GetStreetNames( { "I 95 South" }));
+
+}
+
+}
+
+int main() {
+  test::suite suite("sign");
+
+  // Constructor with list argument
+  suite.test(TEST_CASE(TestListCtor));
+
+  // FindCommonStreetNames
+  suite.test(TEST_CASE(TestFindCommonStreetNames));
+
+  return suite.tear_down();
+}

--- a/test/streetnames.cc
+++ b/test/streetnames.cc
@@ -43,8 +43,8 @@ void TryFindCommonStreetNames(const StreetNames& lhs, const StreetNames& rhs,
                               const StreetNames& expected) {
   StreetNames computed = lhs.FindCommonStreetNames(rhs);
   if (computed != expected) {
-    throw std::runtime_error(
-        "Incorrect street names returned from FindCommonStreetNames");
+    throw std::runtime_error(expected.ToString() +
+        ": Incorrect street names returned from FindCommonStreetNames");
   }
 }
 
@@ -57,9 +57,43 @@ void TestFindCommonStreetNames() {
                            GetStreetNames( { "Fishburn Road", "PA 743" }),
                            GetStreetNames( { }));
 
-  TryFindCommonStreetNames(GetStreetNames( { "Capital Beltway", "I 95 South", "I 495 South" }),
-                           GetStreetNames( { "I 95 South" }),
-                           GetStreetNames( { "I 95 South" }));
+  TryFindCommonStreetNames(GetStreetNames( { "Capital Beltway", "I 95 South",
+      "I 495 South" }),
+                           GetStreetNames( { "I 95 South" }), GetStreetNames( {
+                               "I 95 South" }));
+
+}
+
+void TryFindCommonBaseNames(const StreetNames& lhs, const StreetNames& rhs,
+                            const StreetNames& expected) {
+  StreetNames computed = lhs.FindCommonBaseNames(rhs);
+  if (computed != expected) {
+    throw std::runtime_error(expected.ToString() +
+        ": Incorrect street names returned from FindCommonBaseNames");
+  }
+}
+
+void TestFindCommonBaseNames() {
+  TryFindCommonBaseNames(GetStreetNames( { "Hershey Road", "PA 743 North" }),
+                         GetStreetNames( { "Fishburn Road", "PA 743 North" }),
+                         GetStreetNames( { "PA 743 North" }));
+
+  TryFindCommonBaseNames(GetStreetNames( { "Hershey Road", "PA 743 North" }),
+                         GetStreetNames( { "Fishburn Road", "PA 743" }),
+                         GetStreetNames( { "PA 743 North" }));
+
+  TryFindCommonBaseNames(GetStreetNames( { "Hershey Road", "PA 743" }),
+                         GetStreetNames( { "Fishburn Road", "PA 743 North" }),
+                         GetStreetNames( { "PA 743 North" }));
+
+  TryFindCommonBaseNames(GetStreetNames( { "Hershey Road", "PA 743" }),
+                         GetStreetNames( { "Fishburn Road", "PA 743" }),
+                         GetStreetNames( { "PA 743" }));
+
+  TryFindCommonBaseNames(GetStreetNames( { "Capital Beltway", "I 95 South",
+      "I 495 South" }),
+                         GetStreetNames( { "I 95 South" }), GetStreetNames( {
+                             "I 95 South" }));
 
 }
 
@@ -73,6 +107,9 @@ int main() {
 
   // FindCommonStreetNames
   suite.test(TEST_CASE(TestFindCommonStreetNames));
+
+  // FindCommonBaseNames
+  suite.test(TEST_CASE(TestFindCommonBaseNames));
 
   return suite.tear_down();
 }

--- a/valhalla/odin/streetname.h
+++ b/valhalla/odin/streetname.h
@@ -23,6 +23,8 @@ class StreetName {
 
   std::string GetPostDir() const;
 
+  std::string GetPostCardinalDir() const;
+
   std::string GetBaseName() const;
 
   bool HasSameBaseName(const StreetName& rhs) const;
@@ -34,6 +36,7 @@ class StreetName {
 
   static const std::vector<std::string> pre_dirs_;
   static const std::vector<std::string> post_dirs_;
+  static const std::vector<std::string> post_cardinal_dirs_;
 };
 
 }

--- a/valhalla/odin/streetname.h
+++ b/valhalla/odin/streetname.h
@@ -8,16 +8,16 @@ namespace odin{
 
 class StreetName {
  public:
-  StreetName(const std::string& name);
+  StreetName(const std::string& value);
 
-  const std::string& name() const;
+  const std::string& value() const;
 
   bool operator ==(const StreetName& rhs) const;
 
-  // TODO - add more functionality later
+  // TODO - add more functionality later and comments
 
  protected:
-  std::string name_;
+  std::string value_;
 
 };
 

--- a/valhalla/odin/streetname.h
+++ b/valhalla/odin/streetname.h
@@ -2,9 +2,10 @@
 #define VALHALLA_ODIN_STREETNAME_H_
 
 #include <string>
+#include <vector>
 
-namespace valhalla{
-namespace odin{
+namespace valhalla {
+namespace odin {
 
 class StreetName {
  public:
@@ -14,11 +15,25 @@ class StreetName {
 
   bool operator ==(const StreetName& rhs) const;
 
+  bool StartsWith(const std::string& prefix) const;
+
+  bool EndsWith(const std::string& suffix) const;
+
+  std::string GetPreDir() const;
+
+  std::string GetPostDir() const;
+
+  std::string GetBaseName() const;
+
+  bool HasSameBaseName(const StreetName& rhs) const;
+
   // TODO - add more functionality later and comments
 
  protected:
   std::string value_;
 
+  static const std::vector<std::string> pre_dirs_;
+  static const std::vector<std::string> post_dirs_;
 };
 
 }

--- a/valhalla/odin/streetnames.h
+++ b/valhalla/odin/streetnames.h
@@ -20,6 +20,8 @@ class StreetNames : public std::list<StreetName> {
 
   StreetNames FindCommonStreetNames(StreetNames other_street_names) const;
 
+  StreetNames FindCommonBaseNames(StreetNames other_street_names) const;
+
   // TODO - add more functionality later
 
  protected:


### PR DESCRIPTION
@dnesbitt61 @gknisely @kevinkreiser 

Here are some examples of the improvements:

##########################################
Example#1 - 6 maneuvers collapsed to 1

BEFORE
Turn sharp left onto US 30/Lincoln Highway. | 11.656999 km
Continue onto US 30 West. | 5.005000 km
Continue onto US 30. | 2.397000 km
Continue onto US 30 West. | 2.331000 km
Continue onto US 30/Lincoln Highway. | 3.668000 km
Continue onto Bedford Bypass. | 3.019000 km

AFTER
Turn sharp left onto US 30 West. | 28.077000 km

##########################################
Example#2

BEFORE
Turn left onto East 33rd Street. | 0.155000 km
Continue onto West 33rd Street. | 0.072853 km

AFTER
Turn left onto East 33rd Street. | 0.227853 km

