### PR TITLE
Added doubly digitized u-turn capability

### DIFF
--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -280,6 +280,15 @@ void Maneuver::set_internal_intersection(bool internal_intersection) {
   internal_intersection_ = internal_intersection;
 }
 
+bool Maneuver::HasUsableInternalIntersectionName() const {
+  uint32_t link_count = (end_node_index_ - begin_node_index_);
+  if (internal_intersection_ && !street_names_.empty()
+      && ((link_count == 1) || (link_count == 3))) {
+    return true;
+  }
+  return false;
+}
+
 const Signs& Maneuver::signs() const {
   return signs_;
 }

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -86,6 +86,26 @@ void Maneuver::set_begin_street_names(const StreetNames& begin_street_names) {
   begin_street_names_ = begin_street_names;
 }
 
+void Maneuver::set_begin_street_names(StreetNames&& begin_street_names) {
+  begin_street_names_ = std::move(begin_street_names);
+}
+
+const StreetNames& Maneuver::cross_street_names() const {
+  return cross_street_names_;
+}
+
+StreetNames* Maneuver::mutable_cross_street_names() {
+  return &cross_street_names_;
+}
+
+void Maneuver::set_cross_street_names(const StreetNames& cross_street_names) {
+  cross_street_names_ = cross_street_names;
+}
+
+void Maneuver::set_cross_street_names(StreetNames&& cross_street_names) {
+  cross_street_names_ = std::move(cross_street_names);
+}
+
 const std::string& Maneuver::instruction() const {
   return instruction_;
 }
@@ -301,6 +321,12 @@ std::string Maneuver::ToString() const {
   man_str += " | begin_street_names=";
   man_str += begin_street_names_.ToString();
 
+  man_str += " | cross_street_names=";
+  man_str += cross_street_names_.ToString();
+
+  man_str += " | instruction=";
+  man_str += instruction_;
+
   man_str += " | distance_=";
   man_str += std::to_string(distance_);
 
@@ -381,6 +407,12 @@ std::string Maneuver::ToParameterString() const {
 
   man_str += delim;
   man_str += begin_street_names_.ToParameterString();
+
+  man_str += delim;
+  man_str += cross_street_names_.ToParameterString();
+
+  man_str += delim;
+  man_str += instruction_;
 
   man_str += delim;
   man_str += std::to_string(distance_);

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -429,7 +429,9 @@ std::string Maneuver::ToParameterString() const {
   man_str += cross_street_names_.ToParameterString();
 
   man_str += delim;
+  man_str += "\"";
   man_str += instruction_;
+  man_str += "\"";
 
   man_str += delim;
   man_str += std::to_string(distance_);

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -71,7 +71,7 @@ void Maneuver::set_street_names(StreetNames&& street_names) {
 }
 
 bool Maneuver::HasStreetNames() const {
-  return (street_names_.size() > 0);
+  return (!street_names_.empty());
 }
 
 const StreetNames& Maneuver::begin_street_names() const {
@@ -90,6 +90,10 @@ void Maneuver::set_begin_street_names(StreetNames&& begin_street_names) {
   begin_street_names_ = std::move(begin_street_names);
 }
 
+bool Maneuver::HasBeginStreetNames() const {
+  return (!begin_street_names_.empty());
+}
+
 const StreetNames& Maneuver::cross_street_names() const {
   return cross_street_names_;
 }
@@ -104,6 +108,10 @@ void Maneuver::set_cross_street_names(const StreetNames& cross_street_names) {
 
 void Maneuver::set_cross_street_names(StreetNames&& cross_street_names) {
   cross_street_names_ = std::move(cross_street_names);
+}
+
+bool Maneuver::HasCrossStreetNames() const {
+  return (!cross_street_names_.empty());
 }
 
 const std::string& Maneuver::instruction() const {

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -31,8 +31,8 @@ std::list<Maneuver> ManeuversBuilder::Build() {
   for (Maneuver maneuver : maneuvers) {
     LOG_TRACE("---------------------------------------------");
     LOG_TRACE(std::to_string(man_id++) + ":  ");
-    LOG_TRACE(std::string("  maneuver=") + maneuver.ToString());
     LOG_TRACE(std::string("  maneuver_PARAMETERS=") + maneuver.ToParameterString());
+    LOG_TRACE(std::string("  maneuver=") + maneuver.ToString());
   }
 #endif
 
@@ -46,8 +46,8 @@ std::list<Maneuver> ManeuversBuilder::Build() {
   for (Maneuver maneuver : maneuvers) {
     LOG_TRACE("---------------------------------------------");
     LOG_TRACE(std::to_string(combined_man_id++) + ":  ");
-    LOG_TRACE(std::string("  maneuver=") + maneuver.ToString());
     LOG_TRACE(std::string("  maneuver_PARAMETERS=") + maneuver.ToParameterString());
+    LOG_TRACE(std::string("  maneuver=") + maneuver.ToString());
   }
 #endif
 

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -736,6 +736,7 @@ TripDirections_Maneuver_CardinalDirection ManeuversBuilder::DetermineCardinalDir
   } else if ((heading > 293) && (heading < 337)) {
     return TripDirections_Maneuver_CardinalDirection_kNorthWest;
   }
+  throw std::runtime_error("Turn degree out of range for cardinal direction.");
 }
 
 bool ManeuversBuilder::CanManeuverIncludePrevEdge(Maneuver& maneuver,

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -687,8 +687,19 @@ void ManeuversBuilder::SetSimpleDirectionalManeuverType(Maneuver& maneuver) {
       break;
     }
     case Turn::Type::kReverse: {
-      // TODO: figure this out
-      maneuver.set_type(TripDirections_Maneuver_Type_kUturnLeft);
+      if (IsRightSideOfStreetDriving()) {
+        if (maneuver.turn_degree() < 180) {
+          maneuver.set_type(TripDirections_Maneuver_Type_kUturnRight);
+        } else {
+          maneuver.set_type(TripDirections_Maneuver_Type_kUturnLeft);
+        }
+      } else {
+        if (maneuver.turn_degree() > 180) {
+          maneuver.set_type(TripDirections_Maneuver_Type_kUturnLeft);
+        } else {
+          maneuver.set_type(TripDirections_Maneuver_Type_kUturnRight);
+        }
+      }
       break;
     }
     case Turn::Type::kSharpLeft: {

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -556,12 +556,12 @@ void ManeuversBuilder::SetManeuverType(Maneuver& maneuver) {
   // Process Internal Intersection
   if (maneuver.internal_intersection()) {
     maneuver.set_type(TripDirections_Maneuver_Type_kNone);
-    LOG_TRACE("INTERNAL_INTERSECTION");
+    LOG_TRACE("ManeuverType=INTERNAL_INTERSECTION");
   }
   // Process Turn Channel
   else if (maneuver.turn_channel()) {
     maneuver.set_type(TripDirections_Maneuver_Type_kNone);
-    LOG_TRACE("TURN_CHANNNEL");
+    LOG_TRACE("ManeuverType=TURN_CHANNNEL");
   }
   // Process exit
   else if (maneuver.ramp()
@@ -585,7 +585,7 @@ void ManeuversBuilder::SetManeuverType(Maneuver& maneuver) {
         // TODO: determine how to handle, for now set to right
         maneuver.set_type(TripDirections_Maneuver_Type_kExitRight);
       }
-    }LOG_TRACE("EXIT");
+    }LOG_TRACE("ManeuverType=EXIT");
   }
   // Process on ramp
   else if (maneuver.ramp() && !prev_edge->IsHighway()) {
@@ -612,37 +612,37 @@ void ManeuversBuilder::SetManeuverType(Maneuver& maneuver) {
         // TODO: determine how to handle, for now set to right
         maneuver.set_type(TripDirections_Maneuver_Type_kRampRight);
       }
-    }LOG_TRACE("RAMP");
+    }LOG_TRACE("ManeuverType=RAMP");
   }
   // Process merge
   else if (curr_edge->IsHighway() && prev_edge->ramp()) {
     maneuver.set_type(TripDirections_Maneuver_Type_kMerge);
-    LOG_TRACE("MERGE");
+    LOG_TRACE("ManeuverType=MERGE");
   }
   // Process enter roundabout
   else if (maneuver.roundabout()) {
     maneuver.set_type(TripDirections_Maneuver_Type_kRoundaboutEnter);
-    LOG_TRACE("ROUNDABOUT_ENTER");
+    LOG_TRACE("ManeuverType=ROUNDABOUT_ENTER");
   }
   // Process exit roundabout
   else if (prev_edge->roundabout()) {
     maneuver.set_type(TripDirections_Maneuver_Type_kRoundaboutExit);
-    LOG_TRACE("ROUNDABOUT_EXIT");
+    LOG_TRACE("ManeuverType=ROUNDABOUT_EXIT");
   }
   // Process enter ferry
   else if (maneuver.ferry() || maneuver.rail_ferry()) {
     maneuver.set_type(TripDirections_Maneuver_Type_kFerryEnter);
-    LOG_TRACE("FERRY_ENTER");
+    LOG_TRACE("ManeuverType=FERRY_ENTER");
   }
   // Process exit ferry
   else if (prev_edge->ferry() || prev_edge->rail_ferry()) {
     maneuver.set_type(TripDirections_Maneuver_Type_kFerryExit);
-    LOG_TRACE("FERRY_EXIT");
+    LOG_TRACE("ManeuverType=FERRY_EXIT");
   }
   // Process simple direction
   else {
     SetSimpleDirectionalManeuverType(maneuver);
-    LOG_TRACE("SIMPLE");
+    LOG_TRACE("ManeuverType=SIMPLE");
   }
 
 }
@@ -872,6 +872,11 @@ Maneuver::RelativeDirection ManeuversBuilder::DetermineRelativeDirection(
     return Maneuver::RelativeDirection::kLeft;
   else
     return Maneuver::RelativeDirection::kNone;
+}
+
+bool ManeuversBuilder::IsRightSideOfStreetDriving() const {
+  // TODO: use admin of node to return proper value
+  return true;
 }
 
 }

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -173,8 +173,10 @@ void NarrativeBuilder::FormUturnInstruction(Maneuver& maneuver) {
   text_instruction += FormTurnTypeInstruction(maneuver.type());
   text_instruction += " U-turn";
 
-  // TODO - add intersecting street name
-  // i.e. "at Main Street"
+  if (maneuver.HasCrossStreetNames()) {
+    text_instruction += " at ";
+    text_instruction += maneuver.cross_street_names().ToString();
+  }
 
   if (maneuver.HasStreetNames()) {
     text_instruction += " onto ";

--- a/test/maneuversbuilder.cc
+++ b/test/maneuversbuilder.cc
@@ -51,8 +51,11 @@ void TrySetSimpleDirectionalManeuverType(
   Maneuver maneuver;
   maneuver.set_turn_degree(turn_degree);
   mbTest.SetSimpleDirectionalManeuverType(maneuver);
-  if (maneuver.type() != expected)
-    throw std::runtime_error("Incorrect maneuver type");
+  if (maneuver.type() != expected) {
+    throw std::runtime_error(
+        "Incorrect maneuver type for turn degree="
+            + std::to_string(turn_degree));
+  }
 }
 
 void TestSetSimpleDirectionalManeuverType() {
@@ -93,10 +96,13 @@ void TestSetSimpleDirectionalManeuverType() {
   TrySetSimpleDirectionalManeuverType(169,
                                       TripDirections_Maneuver_Type_kSharpRight);
 
-  // TODO: TripDirections_Maneuver_Type_kUturnLeft for now; update later
+  // Right side of street driving
   // Reverse lower bound
   TrySetSimpleDirectionalManeuverType(170,
-                                      TripDirections_Maneuver_Type_kUturnLeft);
+                                      TripDirections_Maneuver_Type_kUturnRight);
+  // Reverse middle
+  TrySetSimpleDirectionalManeuverType(179,
+                                      TripDirections_Maneuver_Type_kUturnRight);
   // Reverse middle
   TrySetSimpleDirectionalManeuverType(180,
                                       TripDirections_Maneuver_Type_kUturnLeft);

--- a/test/maneuversbuilder.cc
+++ b/test/maneuversbuilder.cc
@@ -2,11 +2,13 @@
 #include "valhalla/odin/maneuver.h"
 #include "valhalla/odin/maneuversbuilder.h"
 #include <valhalla/midgard/util.h>
+#include <valhalla/midgard/logging.h>
 
 #include <string>
 
 using namespace std;
 using namespace valhalla::odin;
+using namespace valhalla::midgard;
 
 namespace {
 
@@ -354,8 +356,12 @@ void TryCombine(ManeuversBuilderTest& mbTest, std::list<Maneuver>& maneuvers,
       man != maneuvers.end(); ++man, ++expected_man) {
     if (man->type() != expected_man->type())
       throw std::runtime_error("Incorrect maneuver type");
-    if (man->distance() != expected_man->distance())
-      throw std::runtime_error("Incorrect maneuver distance");
+    if (!equal<float>(man->distance(), expected_man->distance())) {
+      throw std::runtime_error(
+          "Incorrect maneuver distance=" + std::to_string(man->distance())
+              + std::string(" | Expected distance=")
+              + std::to_string(expected_man->distance()));
+    }
     if (man->time() != expected_man->time())
       throw std::runtime_error("Incorrect maneuver time");
   }
@@ -416,8 +422,10 @@ void PopulateEdge(TripPath_Edge* edge, std::vector<std::string> names,
 void PopulateManeuver(
     Maneuver& maneuver, TripDirections_Maneuver_Type type,
     std::vector<std::string> street_names,
-    std::vector<std::string> begin_street_names, float distance, uint32_t time,
-    uint32_t turn_degree, Maneuver::RelativeDirection begin_relative_direction,
+    std::vector<std::string> begin_street_names,
+    std::vector<std::string> cross_street_names, std::string instruction,
+    float distance, uint32_t time, uint32_t turn_degree,
+    Maneuver::RelativeDirection begin_relative_direction,
     TripDirections_Maneuver_CardinalDirection begin_cardinal_direction,
     uint32_t begin_heading, uint32_t end_heading, uint32_t begin_node_index,
     uint32_t end_node_index, uint32_t begin_shape_index,
@@ -441,6 +449,12 @@ void PopulateManeuver(
   for (auto& begin_street_name : begin_street_names)
     begin_street_name_list->emplace_back(begin_street_name);
 
+  // cross_street_names
+  StreetNames* cross_street_name_list = maneuver.mutable_cross_street_names();
+  for (auto& cross_street_name : cross_street_names)
+    cross_street_name_list->emplace_back(cross_street_name);
+
+  maneuver.set_instruction(instruction);
   maneuver.set_distance(distance);
   maneuver.set_time(time);
   maneuver.set_turn_degree(turn_degree);
@@ -576,14 +590,15 @@ void TestLeftInternalStraightCombine() {
   Maneuver& maneuver1 = maneuvers.back();
   PopulateManeuver(maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "Hershey Road", "PA 743 South" },
-                   { }, 0.453835, 28, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.453835, 28, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 158, 198,
                    0, 4, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   maneuvers.emplace_back();
   Maneuver& maneuver2 = maneuvers.back();
-  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, { }, { },
-                   0.013000, 1, 280, Maneuver::RelativeDirection::kLeft,
+  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, { }, { }, { },
+                   "", 0.013000, 1, 280, Maneuver::RelativeDirection::kLeft,
                    TripDirections_Maneuver_CardinalDirection_kSouthEast, 118,
                    118, 4, 5, 13, 14, 1, 0, 0, 0, 0, 0, 0, 0, 1, { }, { }, { },
                    { });
@@ -591,7 +606,7 @@ void TestLeftInternalStraightCombine() {
   maneuvers.emplace_back();
   Maneuver& maneuver3 = maneuvers.back();
   PopulateManeuver(maneuver3, TripDirections_Maneuver_Type_kRampStraight, { },
-                   { }, 0.505000, 36, 9,
+                   { }, { }, "", 0.505000, 36, 9,
                    Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kSouthEast, 127,
                    130, 5, 7, 14, 20, 1, 0, 0, 0, 0, 0, 0, 0, 0, { }, { {
@@ -602,7 +617,7 @@ void TestLeftInternalStraightCombine() {
   Maneuver& maneuver4 = maneuvers.back();
   PopulateManeuver(maneuver4, TripDirections_Maneuver_Type_kMerge, {
                        "PA 283 East" },
-                   { }, 0.176467, 6, 4,
+                   { }, { }, "", 0.176467, 6, 4,
                    Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kSouthEast, 134,
                    134, 7, 8, 20, 22, 0, 0, 0, 0, 0, 0, 0, 1, 0, { }, { }, { },
@@ -611,7 +626,8 @@ void TestLeftInternalStraightCombine() {
   maneuvers.emplace_back();
   Maneuver& maneuver5 = maneuvers.back();
   PopulateManeuver(maneuver5, TripDirections_Maneuver_Type_kDestination, { },
-                   { }, 0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.000000, 0, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 8, 8,
                    22, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
@@ -623,14 +639,15 @@ void TestLeftInternalStraightCombine() {
   Maneuver& expected_maneuver1 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "Hershey Road", "PA 743 South" },
-                   { }, 0.453835, 28, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.453835, 28, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 158, 198,
                    0, 4, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   expected_maneuvers.emplace_back();
   Maneuver& expected_maneuver2 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver2, TripDirections_Maneuver_Type_kRampLeft,
-                   { }, { }, 0.518000, 37, 289,
+                   { }, { }, { }, "", 0.518000, 37, 289,
                    Maneuver::RelativeDirection::kLeft,
                    TripDirections_Maneuver_CardinalDirection_kSouthEast, 127,
                    130, 4, 7, 13, 20, 1, 0, 0, 0, 0, 0, 0, 0, 0, { }, { {
@@ -641,7 +658,7 @@ void TestLeftInternalStraightCombine() {
   Maneuver& expected_maneuver3 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver3, TripDirections_Maneuver_Type_kMerge, {
                        "PA 283 East" },
-                   { }, 0.176467, 6, 4,
+                   { }, { }, "", 0.176467, 6, 4,
                    Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kSouthEast, 134,
                    134, 7, 8, 20, 22, 0, 0, 0, 0, 0, 0, 0, 1, 0, { }, { }, { },
@@ -650,7 +667,7 @@ void TestLeftInternalStraightCombine() {
   expected_maneuvers.emplace_back();
   Maneuver& expected_maneuver4 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver4,
-                   TripDirections_Maneuver_Type_kDestination, { }, { },
+                   TripDirections_Maneuver_Type_kDestination, { }, { }, { }, "",
                    0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 8, 8,
                    22, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
@@ -744,7 +761,8 @@ void TestStraightInternalLeftCombine() {
   Maneuver& maneuver1 = maneuvers.back();
   PopulateManeuver(maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "PA 283 West" },
-                   { }, 0.511447, 18, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.511447, 18, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorthWest, 315,
                    316, 0, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, { }, { }, { },
                    { });
@@ -752,7 +770,8 @@ void TestStraightInternalLeftCombine() {
   maneuvers.emplace_back();
   Maneuver& maneuver2 = maneuvers.back();
   PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kExitRight, { }, { },
-                   0.397000, 29, 6, Maneuver::RelativeDirection::kKeepRight,
+                   { }, "", 0.397000, 29, 6,
+                   Maneuver::RelativeDirection::kKeepRight,
                    TripDirections_Maneuver_CardinalDirection_kNorthWest, 322,
                    330, 1, 2, 3, 12, 1, 0, 0, 0, 0, 0, 0, 0, 0, { }, { {
                        "PA 743", "0" } },
@@ -761,7 +780,8 @@ void TestStraightInternalLeftCombine() {
   maneuvers.emplace_back();
   Maneuver& maneuver3 = maneuvers.back();
   PopulateManeuver(maneuver3, TripDirections_Maneuver_Type_kRampLeft, { }, { },
-                   0.050000, 4, 338, Maneuver::RelativeDirection::kKeepLeft,
+                   { }, "", 0.050000, 4, 338,
+                   Maneuver::RelativeDirection::kKeepLeft,
                    TripDirections_Maneuver_CardinalDirection_kNorthWest, 308,
                    292, 2, 3, 12, 17, 1, 0, 0, 0, 0, 0, 0, 0, 0, { }, { {
                        "PA 743 South", "0" } },
@@ -769,8 +789,9 @@ void TestStraightInternalLeftCombine() {
 
   maneuvers.emplace_back();
   Maneuver& maneuver4 = maneuvers.back();
-  PopulateManeuver(maneuver4, TripDirections_Maneuver_Type_kNone, { }, { },
-                   0.012000, 1, 357, Maneuver::RelativeDirection::kKeepStraight,
+  PopulateManeuver(maneuver4, TripDirections_Maneuver_Type_kNone, { }, { }, { },
+                   "", 0.012000, 1, 357,
+                   Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kWest, 289, 289, 3,
                    4, 17, 18, 1, 0, 0, 0, 0, 0, 0, 0, 1, { }, { }, { }, { });
 
@@ -778,14 +799,16 @@ void TestStraightInternalLeftCombine() {
   Maneuver& maneuver5 = maneuvers.back();
   PopulateManeuver(maneuver5, TripDirections_Maneuver_Type_kLeft, {
                        "Hershey Road", "PA 743 South" },
-                   { }, 0.486000, 30, 269, Maneuver::RelativeDirection::kLeft,
+                   { }, { }, "", 0.486000, 30, 269,
+                   Maneuver::RelativeDirection::kLeft,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 198, 19, 4,
                    9, 18, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   maneuvers.emplace_back();
   Maneuver& maneuver6 = maneuvers.back();
   PopulateManeuver(maneuver6, TripDirections_Maneuver_Type_kDestination, { },
-                   { }, 0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.000000, 0, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 9, 9,
                    25, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
@@ -797,7 +820,8 @@ void TestStraightInternalLeftCombine() {
   Maneuver& expected_maneuver1 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "PA 283 West" },
-                   { }, 0.511447, 18, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.511447, 18, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorthWest, 315,
                    316, 0, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, { }, { }, { },
                    { });
@@ -805,7 +829,7 @@ void TestStraightInternalLeftCombine() {
   expected_maneuvers.emplace_back();
   Maneuver& expected_maneuver2 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver2, TripDirections_Maneuver_Type_kExitRight,
-                   { }, { }, 0.397000, 29, 6,
+                   { }, { }, { }, "", 0.397000, 29, 6,
                    Maneuver::RelativeDirection::kKeepRight,
                    TripDirections_Maneuver_CardinalDirection_kNorthWest, 322,
                    330, 1, 2, 3, 12, 1, 0, 0, 0, 0, 0, 0, 0, 0, { }, { {
@@ -815,7 +839,7 @@ void TestStraightInternalLeftCombine() {
   expected_maneuvers.emplace_back();
   Maneuver& expected_maneuver3 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver3, TripDirections_Maneuver_Type_kRampLeft,
-                   { }, { }, 0.050000, 4, 338,
+                   { }, { }, { }, "", 0.050000, 4, 338,
                    Maneuver::RelativeDirection::kKeepLeft,
                    TripDirections_Maneuver_CardinalDirection_kNorthWest, 308,
                    292, 2, 3, 12, 17, 1, 0, 0, 0, 0, 0, 0, 0, 0, { }, { {
@@ -826,14 +850,15 @@ void TestStraightInternalLeftCombine() {
   Maneuver& expected_maneuver4 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver4, TripDirections_Maneuver_Type_kLeft, {
                        "Hershey Road", "PA 743 South" },
-                   { }, 0.498000, 31, 266, Maneuver::RelativeDirection::kLeft,
+                   { }, { }, "", 0.498000, 31, 266,
+                   Maneuver::RelativeDirection::kLeft,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 198, 19, 3,
                    9, 17, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   expected_maneuvers.emplace_back();
   Maneuver& expected_maneuver5 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver5,
-                   TripDirections_Maneuver_Type_kDestination, { }, { },
+                   TripDirections_Maneuver_Type_kDestination, { }, { }, { }, "",
                    0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 9, 9,
                    25, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
@@ -896,14 +921,16 @@ void TestStraightInternalLeftInternalCombine() {
   Maneuver& maneuver1 = maneuvers.back();
   PopulateManeuver(maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "Broken Land Parkway" },
-                   { }, 0.137148, 7, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.137148, 7, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorthEast, 26, 24,
                    0, 2, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   maneuvers.emplace_back();
   Maneuver& maneuver2 = maneuvers.back();
-  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, { }, { },
-                   0.047000, 3, 1, Maneuver::RelativeDirection::kKeepStraight,
+  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, { }, { }, { },
+                   "", 0.047000, 3, 1,
+                   Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kNorthEast, 25,
                    291, 2, 4, 3, 5, 0, 0, 0, 0, 0, 0, 0, 0, 1, { }, { }, { },
                    { });
@@ -912,7 +939,7 @@ void TestStraightInternalLeftInternalCombine() {
   Maneuver& maneuver3 = maneuvers.back();
   PopulateManeuver(maneuver3, TripDirections_Maneuver_Type_kContinue, {
                        "Patuxent Woods Drive" },
-                   { }, 0.059840, 5, 1,
+                   { }, { }, "", 0.059840, 5, 1,
                    Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kWest, 292, 270, 4,
                    5, 5, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
@@ -920,7 +947,8 @@ void TestStraightInternalLeftInternalCombine() {
   maneuvers.emplace_back();
   Maneuver& maneuver4 = maneuvers.back();
   PopulateManeuver(maneuver4, TripDirections_Maneuver_Type_kDestination, { },
-                   { }, 0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.000000, 0, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 5, 5,
                    8, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
@@ -932,7 +960,8 @@ void TestStraightInternalLeftInternalCombine() {
   Maneuver& expected_maneuver1 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "Broken Land Parkway" },
-                   { }, 0.137148, 7, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.137148, 7, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorthEast, 26, 24,
                    0, 2, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
@@ -940,14 +969,15 @@ void TestStraightInternalLeftInternalCombine() {
   Maneuver& expected_maneuver2 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver2, TripDirections_Maneuver_Type_kLeft, {
                        "Patuxent Woods Drive" },
-                   { }, 0.106840, 8, 268, Maneuver::RelativeDirection::kLeft,
+                   { }, { }, "", 0.106840, 8, 268,
+                   Maneuver::RelativeDirection::kLeft,
                    TripDirections_Maneuver_CardinalDirection_kWest, 292, 270, 2,
                    5, 3, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   expected_maneuvers.emplace_back();
   Maneuver& expected_maneuver3 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver3,
-                   TripDirections_Maneuver_Type_kDestination, { }, { },
+                   TripDirections_Maneuver_Type_kDestination, { }, { }, { }, "",
                    0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 5, 5,
                    8, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
@@ -1050,14 +1080,16 @@ void TestStraightInternalStraightCombine() {
   Maneuver& maneuver1 = maneuvers.back();
   PopulateManeuver(maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "MD 43 East", "White Marsh Boulevard" },
-                   { }, 0.206902, 9, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.206902, 9, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorthEast, 59, 94,
                    0, 2, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   maneuvers.emplace_back();
   Maneuver& maneuver2 = maneuvers.back();
-  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, { }, { },
-                   0.018000, 1, 2, Maneuver::RelativeDirection::kKeepStraight,
+  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, { }, { }, { },
+                   "", 0.018000, 1, 2,
+                   Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kEast, 96, 96, 2,
                    3, 8, 9, 0, 0, 0, 0, 0, 0, 0, 0, 1, { }, { }, { }, { });
 
@@ -1065,15 +1097,16 @@ void TestStraightInternalStraightCombine() {
   Maneuver& maneuver3 = maneuvers.back();
   PopulateManeuver(maneuver3, TripDirections_Maneuver_Type_kContinue, {
                        "MD 43 East", "White Marsh Boulevard" },
-                   { }, 1.005000, 45, 358,
+                   { }, { }, "", 1.005000, 45, 358,
                    Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kEast, 94, 86, 3,
                    7, 9, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   maneuvers.emplace_back();
   Maneuver& maneuver4 = maneuvers.back();
-  PopulateManeuver(maneuver4, TripDirections_Maneuver_Type_kNone, { }, { },
-                   0.015000, 1, 7, Maneuver::RelativeDirection::kKeepStraight,
+  PopulateManeuver(maneuver4, TripDirections_Maneuver_Type_kNone, { }, { }, { },
+                   "", 0.015000, 1, 7,
+                   Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kEast, 93, 93, 7,
                    8, 33, 34, 0, 0, 0, 0, 0, 0, 0, 0, 1, { }, { }, { }, { });
 
@@ -1081,7 +1114,7 @@ void TestStraightInternalStraightCombine() {
   Maneuver& maneuver5 = maneuvers.back();
   PopulateManeuver(maneuver5, TripDirections_Maneuver_Type_kContinue, {
                        "MD 43 East", "White Marsh Boulevard" },
-                   { }, 0.294965, 15, 357,
+                   { }, { }, "", 0.294965, 15, 357,
                    Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kEast, 90, 89, 8,
                    10, 34, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
@@ -1089,7 +1122,8 @@ void TestStraightInternalStraightCombine() {
   maneuvers.emplace_back();
   Maneuver& maneuver6 = maneuvers.back();
   PopulateManeuver(maneuver6, TripDirections_Maneuver_Type_kDestination, { },
-                   { }, 0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.000000, 0, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 10,
                    10, 40, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
@@ -1101,17 +1135,247 @@ void TestStraightInternalStraightCombine() {
   Maneuver& expected_maneuver1 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "MD 43 East", "White Marsh Boulevard" },
-                   { }, 1.539867, 71, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 1.539867, 71, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorthEast, 59, 10,
                    0, 10, 0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   expected_maneuvers.emplace_back();
   Maneuver& expected_maneuver2 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver2,
-                   TripDirections_Maneuver_Type_kDestination, { }, { },
+                   TripDirections_Maneuver_Type_kDestination, { }, { }, { }, "",
                    0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 10,
                    10, 40, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
+
+  TryCombine(mbTest, maneuvers, expected_maneuvers);
+}
+
+void TestLeftInternalUturnCombine() {
+  TripPath path;
+  TripPath_Node* node;
+  TripPath_Edge* edge;
+
+  ///////////////////////////////////////////////////////////////////////////
+  // node:0
+  node = path.add_node();
+  edge = node->add_edge();
+  PopulateEdge(edge, { "Jonestown Road", "US 22" }, 0.062923, 75.000000,
+               TripPath_RoadClass_kPrimary, 36, 32, 0, 2,
+               TripPath_Driveability_kBoth, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+               { }, { }, { }, { });
+
+  // node:1 TURN_CHANNNEL
+  node = path.add_node();
+  edge = node->add_edge();
+  PopulateEdge(edge, { "Devonshire Road" }, 0.013000, 50.000000,
+               TripPath_RoadClass_kTertiary, 299, 299, 2, 3,
+               TripPath_Driveability_kBoth, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+               { }, { }, { }, { });
+
+  // node:2
+  node = path.add_node();
+  edge = node->add_edge();
+  PopulateEdge(edge, { "Jonestown Road", "US 22" }, 0.059697, 75.000000,
+               TripPath_RoadClass_kPrimary, 212, 221, 3, 5,
+               TripPath_Driveability_kBoth, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+               { }, { }, { }, { });
+
+  ManeuversBuilderTest mbTest(static_cast<EnhancedTripPath*>(&path));
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Create maneuver list
+  std::list<Maneuver> maneuvers;
+  maneuvers.emplace_back();
+  Maneuver& maneuver1 = maneuvers.back();
+  PopulateManeuver(maneuver1, TripDirections_Maneuver_Type_kStart, {
+                       "Jonestown Road", "US 22" },
+                   { }, { }, "", 0.062923, 3, 0,
+                   Maneuver::RelativeDirection::kNone,
+                   TripDirections_Maneuver_CardinalDirection_kNorthEast, 36, 32,
+                   0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
+
+  maneuvers.emplace_back();
+  Maneuver& maneuver2 = maneuvers.back();
+  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, {
+                       "Devonshire Road" },
+                   { }, { }, "", 0.013000, 1, 267,
+                   Maneuver::RelativeDirection::kLeft,
+                   TripDirections_Maneuver_CardinalDirection_kNorthWest, 299,
+                   299, 1, 2, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 1, { }, { }, { },
+                   { });
+
+  maneuvers.emplace_back();
+  Maneuver& maneuver3 = maneuvers.back();
+  PopulateManeuver(maneuver3, TripDirections_Maneuver_Type_kLeft, {
+                       "Jonestown Road", "US 22" },
+                   { }, { }, "", 0.059697, 3, 273,
+                   Maneuver::RelativeDirection::kLeft,
+                   TripDirections_Maneuver_CardinalDirection_kSouthWest, 212,
+                   221, 2, 3, 3, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { });
+
+  maneuvers.emplace_back();
+  Maneuver& maneuver4 = maneuvers.back();
+  PopulateManeuver(maneuver4, TripDirections_Maneuver_Type_kDestination, { },
+                   { }, { }, "", 0.000000, 0, 0,
+                   Maneuver::RelativeDirection::kNone,
+                   TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 3, 3,
+                   5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Create expected combined maneuver list
+  std::list<Maneuver> expected_maneuvers;
+
+  expected_maneuvers.emplace_back();
+  Maneuver& expected_maneuver1 = expected_maneuvers.back();
+  PopulateManeuver(expected_maneuver1, TripDirections_Maneuver_Type_kStart, {
+                       "Jonestown Road", "US 22" },
+                   { }, { }, "", 0.062923, 3, 0,
+                   Maneuver::RelativeDirection::kNone,
+                   TripDirections_Maneuver_CardinalDirection_kNorthEast, 36, 32,
+                   0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
+
+  expected_maneuvers.emplace_back();
+  Maneuver& expected_maneuver2 = expected_maneuvers.back();
+  PopulateManeuver(expected_maneuver2, TripDirections_Maneuver_Type_kUturnLeft,
+                   { "Jonestown Road", "US 22" }, { }, { "Devonshire Road" },
+                   "", 0.072697, 4, 180, Maneuver::RelativeDirection::KReverse,
+                   TripDirections_Maneuver_CardinalDirection_kSouthWest, 212,
+                   221, 1, 3, 2, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { });
+
+  expected_maneuvers.emplace_back();
+  Maneuver& expected_maneuver3 = expected_maneuvers.back();
+  PopulateManeuver(expected_maneuver3,
+                   TripDirections_Maneuver_Type_kDestination, { }, { }, { }, "",
+                   0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
+                   TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 3, 3,
+                   5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
+
+  TryCombine(mbTest, maneuvers, expected_maneuvers);
+}
+
+void TestStraightInternalLeftInternalStraightInternalUturnCombine() {
+  TripPath path;
+  TripPath_Node* node;
+  TripPath_Edge* edge;
+
+  ///////////////////////////////////////////////////////////////////////////
+  // node:0
+  node = path.add_node();
+  edge = node->add_edge();
+  PopulateEdge(edge, { "MD 24", "Vietnam Veterans Memorial Highway" }, 0.071404,
+               89.000000, TripPath_RoadClass_kTrunk, 335, 334, 0, 2,
+               TripPath_Driveability_kBoth, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+               { }, { }, { }, { });
+
+  // node:1 TURN_CHANNNEL
+  node = path.add_node();
+  edge = node->add_edge();
+  PopulateEdge(edge, { "MD 24", "Vietnam Veterans Memorial Highway" }, 0.012000,
+               89.000000, TripPath_RoadClass_kTrunk, 334, 334, 2, 3,
+               TripPath_Driveability_kBoth, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+               { }, { }, { }, { });
+
+  // node:2
+  node = path.add_node();
+  edge = node->add_edge();
+  PopulateEdge(edge, { "Bel Air South Parkway" }, 0.025000, 48.000000,
+               TripPath_RoadClass_kSecondary, 245, 245, 3, 4,
+               TripPath_Driveability_kBoth, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+               { }, { }, { }, { });
+
+  // node:3
+  node = path.add_node();
+  edge = node->add_edge();
+  PopulateEdge(edge, { "MD 24", "Vietnam Veterans Memorial Highway" }, 0.012000,
+               89.000000, TripPath_RoadClass_kTrunk, 153, 153, 4, 5,
+               TripPath_Driveability_kBoth, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+               { }, { }, { }, { });
+
+  // node:4
+  node = path.add_node();
+  edge = node->add_edge();
+  PopulateEdge(edge, { "MD 24", "Vietnam Veterans Memorial Highway" }, 0.070695,
+               89.000000, TripPath_RoadClass_kTrunk, 155, 156, 5, 9,
+               TripPath_Driveability_kBoth, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+               { }, { }, { }, { });
+
+  ManeuversBuilderTest mbTest(static_cast<EnhancedTripPath*>(&path));
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Create maneuver list
+  std::list<Maneuver> maneuvers;
+  maneuvers.emplace_back();
+  Maneuver& maneuver1 = maneuvers.back();
+  PopulateManeuver(maneuver1, TripDirections_Maneuver_Type_kStart, { "MD 24",
+                       "Vietnam Veterans Memorial Highway" },
+                   { }, { }, "", 0.071404, 3, 0,
+                   Maneuver::RelativeDirection::kNone,
+                   TripDirections_Maneuver_CardinalDirection_kNorthWest, 335,
+                   334, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { });
+
+  maneuvers.emplace_back();
+  Maneuver& maneuver2 = maneuvers.back();
+  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, {
+                       "Bel Air South Parkway" },
+                   { }, { }, "", 0.049000, 2, 0,
+                   Maneuver::RelativeDirection::kKeepStraight,
+                   TripDirections_Maneuver_CardinalDirection_kNorthWest, 334,
+                   153, 1, 4, 2, 5, 0, 0, 0, 0, 0, 0, 0, 0, 1, { }, { }, { },
+                   { });
+
+  maneuvers.emplace_back();
+  Maneuver& maneuver3 = maneuvers.back();
+  PopulateManeuver(maneuver3, TripDirections_Maneuver_Type_kContinue, { "MD 24",
+                       "Vietnam Veterans Memorial Highway" },
+                   { }, { }, "", 0.070695, 3, 2,
+                   Maneuver::RelativeDirection::kKeepStraight,
+                   TripDirections_Maneuver_CardinalDirection_kSouthEast, 155,
+                   156, 4, 5, 5, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { });
+
+  maneuvers.emplace_back();
+  Maneuver& maneuver4 = maneuvers.back();
+  PopulateManeuver(maneuver4, TripDirections_Maneuver_Type_kDestination, { },
+                   { }, { }, "", 0.000000, 0, 0,
+                   Maneuver::RelativeDirection::kNone,
+                   TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 5, 5,
+                   9, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Create expected combined maneuver list
+  std::list<Maneuver> expected_maneuvers;
+
+  expected_maneuvers.emplace_back();
+  Maneuver& expected_maneuver1 = expected_maneuvers.back();
+  PopulateManeuver(expected_maneuver1, TripDirections_Maneuver_Type_kStart, {
+                       "MD 24", "Vietnam Veterans Memorial Highway" },
+                   { }, { }, "", 0.071404, 3, 0,
+                   Maneuver::RelativeDirection::kNone,
+                   TripDirections_Maneuver_CardinalDirection_kNorthWest, 335,
+                   334, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { });
+
+  expected_maneuvers.emplace_back();
+  Maneuver& expected_maneuver2 = expected_maneuvers.back();
+  PopulateManeuver(expected_maneuver2, TripDirections_Maneuver_Type_kUturnLeft,
+                   { "MD 24", "Vietnam Veterans Memorial Highway" }, { }, {
+                       "Bel Air South Parkway" },
+                   "", 0.119695, 5, 181, Maneuver::RelativeDirection::KReverse,
+                   TripDirections_Maneuver_CardinalDirection_kSouthEast, 155,
+                   156, 1, 5, 2, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { });
+
+  expected_maneuvers.emplace_back();
+  Maneuver& expected_maneuver3 = expected_maneuvers.back();
+  PopulateManeuver(expected_maneuver3,
+                   TripDirections_Maneuver_Type_kDestination, { }, { }, { }, "",
+                   0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
+                   TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 5, 5,
+                   9, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   TryCombine(mbTest, maneuvers, expected_maneuvers);
 }
@@ -1154,14 +1418,15 @@ void TestSimpleRightTurnChannelCombine() {
   Maneuver& maneuver1 = maneuvers.back();
   PopulateManeuver(maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "MD 43 East", "White Marsh Boulevard" },
-                   { }, 0.091237, 4, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.091237, 4, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorthEast, 59, 94,
                    0, 1, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
   maneuvers.emplace_back();
   Maneuver& maneuver2 = maneuvers.back();
-  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, { }, { },
-                   0.142000, 5, 11, Maneuver::RelativeDirection::kKeepRight,
+  PopulateManeuver(maneuver2, TripDirections_Maneuver_Type_kNone, { }, { }, { },
+                   "", 0.142000, 5, 11, Maneuver::RelativeDirection::kKeepRight,
                    TripDirections_Maneuver_CardinalDirection_kEast, 105, 179, 1,
                    2, 4, 11, 0, 1, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
@@ -1169,7 +1434,7 @@ void TestSimpleRightTurnChannelCombine() {
   Maneuver& maneuver3 = maneuvers.back();
   PopulateManeuver(maneuver3, TripDirections_Maneuver_Type_kContinue, {
                        "Perry Hall Boulevard" },
-                   { }, 0.065867, 4, 9,
+                   { }, { }, "", 0.065867, 4, 9,
                    Maneuver::RelativeDirection::kKeepStraight,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 188, 188,
                    2, 3, 11, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
@@ -1177,7 +1442,8 @@ void TestSimpleRightTurnChannelCombine() {
   maneuvers.emplace_back();
   Maneuver& maneuver4 = maneuvers.back();
   PopulateManeuver(maneuver4, TripDirections_Maneuver_Type_kDestination, { },
-                   { }, 0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.000000, 0, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 3, 3,
                    14, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
@@ -1189,7 +1455,8 @@ void TestSimpleRightTurnChannelCombine() {
   Maneuver& expected_maneuver1 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver1, TripDirections_Maneuver_Type_kStart, {
                        "MD 43 East", "White Marsh Boulevard" },
-                   { }, 0.091237, 4, 0, Maneuver::RelativeDirection::kNone,
+                   { }, { }, "", 0.091237, 4, 0,
+                   Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorthEast, 59, 94,
                    0, 1, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
 
@@ -1197,7 +1464,7 @@ void TestSimpleRightTurnChannelCombine() {
   Maneuver& expected_maneuver2 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver2, TripDirections_Maneuver_Type_kRight, {
                        "Perry Hall Boulevard" },
-                   { }, 0.207867, 9, 94,
+                   { }, { }, "", 0.207867, 9, 94,
                    Maneuver::RelativeDirection::kKeepRight,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 188, 188,
                    1, 3, 4, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
@@ -1205,7 +1472,7 @@ void TestSimpleRightTurnChannelCombine() {
   expected_maneuvers.emplace_back();
   Maneuver& expected_maneuver3 = expected_maneuvers.back();
   PopulateManeuver(expected_maneuver3,
-                   TripDirections_Maneuver_Type_kDestination, { }, { },
+                   TripDirections_Maneuver_Type_kDestination, { }, { }, { }, "",
                    0.000000, 0, 0, Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorth, 0, 0, 3, 3,
                    14, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { });
@@ -1241,6 +1508,13 @@ int main() {
 
   // StraightInternalStraightCombine
   suite.test(TEST_CASE(TestStraightInternalStraightCombine));
+
+  // LeftInternalUturnCombine
+  suite.test(TEST_CASE(TestLeftInternalUturnCombine));
+
+  // StraightInternalLeftInternalStraightInternalUturnCombine
+  suite.test(
+      TEST_CASE(TestStraightInternalLeftInternalStraightInternalUturnCombine));
 
   // SimpleRightTurnChannelCombine
   suite.test(TEST_CASE(TestSimpleRightTurnChannelCombine));

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -32,18 +32,19 @@ class Maneuver {
   StreetNames* mutable_street_names();
   void set_street_names(const StreetNames& street_names);
   void set_street_names(StreetNames&& street_names);
-
   bool HasStreetNames() const;
 
   const StreetNames& begin_street_names() const;
   StreetNames* mutable_begin_street_names();
   void set_begin_street_names(const StreetNames& begin_street_names);
   void set_begin_street_names(StreetNames&& begin_street_names);
+  bool HasBeginStreetNames() const;
 
   const StreetNames& cross_street_names() const;
   StreetNames* mutable_cross_street_names();
   void set_cross_street_names(const StreetNames& cross_street_names);
   void set_cross_street_names(StreetNames&& cross_street_names);
+  bool HasCrossStreetNames() const;
 
   const std::string& instruction() const;
   void set_instruction(const std::string& instruction);

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -108,6 +108,7 @@ class Maneuver {
 
   bool internal_intersection() const;
   void set_internal_intersection(bool internal_intersection);
+  bool HasUsableInternalIntersectionName() const;
 
   const Signs& signs() const;
   Signs* mutable_signs();

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -38,6 +38,12 @@ class Maneuver {
   const StreetNames& begin_street_names() const;
   StreetNames* mutable_begin_street_names();
   void set_begin_street_names(const StreetNames& begin_street_names);
+  void set_begin_street_names(StreetNames&& begin_street_names);
+
+  const StreetNames& cross_street_names() const;
+  StreetNames* mutable_cross_street_names();
+  void set_cross_street_names(const StreetNames& cross_street_names);
+  void set_cross_street_names(StreetNames&& cross_street_names);
 
   const std::string& instruction() const;
   void set_instruction(const std::string& instruction);
@@ -120,6 +126,7 @@ class Maneuver {
   TripDirections_Maneuver_Type type_;
   StreetNames street_names_;
   StreetNames begin_street_names_;
+  StreetNames cross_street_names_;
   std::string instruction_;
   float distance_;
   uint32_t time_;

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -62,6 +62,8 @@ class ManeuversBuilder {
 
   bool IsRightSideOfStreetDriving() const;
 
+  bool UsableInternalIntersectionName(Maneuver& maneuver, int node_index) const;
+
   EnhancedTripPath* trip_path_;
 
 };

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -60,6 +60,8 @@ class ManeuversBuilder {
   static Maneuver::RelativeDirection DetermineRelativeDirection(
       uint32_t turn_degree);
 
+  bool IsRightSideOfStreetDriving() const;
+
   EnhancedTripPath* trip_path_;
 
 };


### PR DESCRIPTION
@dnesbitt61 @gknisely @kevinkreiser 

Example:
1: Start out going northwest on MD 24/Vietnam Veterans Memorial Highway. | 0.071404 km
2: Make a left U-turn at Bel Air South Parkway onto MD 24/Vietnam Veterans Memorial Highway. | 0.119695 km
3: You have arrived at your destination. | 0.000000 km

![dduturn](https://cloud.githubusercontent.com/assets/7515853/6516191/e54b3f24-c35d-11e4-9fd4-88e1bd37e99b.png)
