### PR TITLE
Fixed invalid u-turn direction

### DIFF
--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -43,7 +43,9 @@ Maneuver::Maneuver()
       portions_toll_(false),
       portions_unpaved_(false),
       portions_highway_(false),
-      internal_intersection_(false) {
+      internal_intersection_(false),
+      internal_right_turn_count_(0),
+      internal_left_turn_count_(0) {
 }
 
 const TripDirections_Maneuver_Type& Maneuver::type() const {
@@ -325,6 +327,23 @@ bool Maneuver::HasExitNameSign() const {
   return signs_.HasExitName();
 }
 
+uint32_t Maneuver::internal_right_turn_count() const {
+  return internal_right_turn_count_;
+}
+
+void Maneuver::set_internal_right_turn_count(
+    uint32_t internal_right_turn_count) {
+  internal_right_turn_count_ = internal_right_turn_count;
+}
+
+uint32_t Maneuver::internal_left_turn_count() const {
+  return internal_left_turn_count_;
+}
+
+void Maneuver::set_internal_left_turn_count(uint32_t internal_left_turn_count) {
+  internal_left_turn_count_ = internal_left_turn_count;
+}
+
 std::string Maneuver::ToString() const {
   std::string man_str;
   man_str.reserve(256);
@@ -406,6 +425,12 @@ std::string Maneuver::ToString() const {
 
   man_str += " | ";
   man_str += signs_.ToString();
+
+  man_str += " | internal_right_turn_count=";
+  man_str += std::to_string(internal_right_turn_count_);
+
+  man_str += " | internal_left_turn_count=";
+  man_str += std::to_string(internal_left_turn_count_);
 
   return man_str;
 }
@@ -498,6 +523,12 @@ std::string Maneuver::ToParameterString() const {
 
   man_str += delim;
   man_str += signs_.ToParameterString();
+
+  man_str += delim;
+  man_str += std::to_string(internal_right_turn_count_);
+
+  man_str += delim;
+  man_str += std::to_string(internal_left_turn_count_);
 
   return man_str;
 }

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -120,6 +120,12 @@ class Maneuver {
   bool HasExitTowardSign() const;
   bool HasExitNameSign() const;
 
+  uint32_t internal_right_turn_count() const;
+  void set_internal_right_turn_count(uint32_t internal_right_turn_count);
+
+  uint32_t internal_left_turn_count() const;
+  void set_internal_left_turn_count(uint32_t internal_left_turn_count);
+
   std::string ToString() const;
 
   std::string ToParameterString() const;
@@ -151,6 +157,8 @@ class Maneuver {
   bool portions_highway_;
   bool internal_intersection_;
   Signs signs_;
+  uint32_t internal_right_turn_count_;
+  uint32_t internal_left_turn_count_;
 
   // TODO notes
 

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -64,6 +64,8 @@ class ManeuversBuilder {
 
   bool UsableInternalIntersectionName(Maneuver& maneuver, int node_index) const;
 
+  void UpdateInternalTurnCount(Maneuver& maneuver, int node_index) const;
+
   EnhancedTripPath* trip_path_;
 
 };


### PR DESCRIPTION
@dnesbitt61 @gknisely @kevinkreiser 

Example #1:
OLD: Make a right U-turn onto Stonewall Shops Square.
NEW: Make a left U-turn onto Stonewall Shops Square.


Example #2:
OLD: Make a right U-turn at Moravia Park Drive onto US 40 West/Pulaski Highway.
NEW: Make a left U-turn at Moravia Park Drive onto US 40 West/Pulaski Highway.
![leftuturnproperdirection](https://cloud.githubusercontent.com/assets/7515853/6536970/3240e9e2-c420-11e4-94f7-fa81d9618946.png)

