### PR TITLE
first draft of odin service layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ libtool
 # built objects
 valhalla/proto
 src/proto
-#odin
+odin_service
 *.o
 .deps/
 .dirstamp

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,8 @@ nobase_include_HEADERS = \
 	valhalla/odin/maneuver.h \
 	valhalla/odin/sign.h \
 	valhalla/odin/signs.h \
-	valhalla/odin/util.h
+	valhalla/odin/util.h \
+	valhalla/odin/service.h
 libvalhalla_odin_la_SOURCES = \
 	src/proto/trippath.pb.cc \
 	src/proto/tripdirections.pb.cc \
@@ -71,15 +72,16 @@ libvalhalla_odin_la_SOURCES = \
 	src/odin/maneuver.cc \
 	src/odin/sign.cc \
 	src/odin/signs.cc \
-	src/odin/util.cc
+	src/odin/util.cc \
+	src/odin/service.cc
 libvalhalla_odin_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-libvalhalla_odin_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS)
+libvalhalla_odin_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB)
 
 #distributed executables
-#bin_PROGRAMS = odin
-#odin_SOURCES = 
-#odin_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-#odin_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIBS@ @PROTOC_LIBS@ -lz libvalhalla_odin.la
+bin_PROGRAMS = odin_service
+odin_service_SOURCES = src/odin/odin_service.cc
+odin_service_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
+odin_service_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) @PROTOC_LIBS@ -lz libvalhalla_odin.la
 
 # tests
 check_PROGRAMS = \

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
     - scripts/install_service_deps.sh
     #valhalla dependencies
-    - cd deps; for dep in midgard baldr; do cd $dep; ./autogen.sh && ./configure && sudo make -j4 install; cd ..; done
+    - cd deps; for dep in midgard baldr; do cd $dep; ./autogen.sh && ./configure CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE && sudo make -j4 install; cd ..; done
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  environment:
+    LD_LIBRARY_PATH: .:`cat /etc/ld.so.conf.d/* | grep -v -E "#" | tr "\\n" ":" | sed -e "s/:$//g"`
   pre:
     - sudo add-apt-repository -y ppa:boost-latest/ppa
     #- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -17,14 +19,15 @@ dependencies:
     - sudo apt-get remove --purge -y libboost*
     - sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev lcov protobuf-compiler libprotobuf-dev
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+    - scripts/install_service_deps.sh
     #valhalla dependencies
     - cd deps; for dep in midgard baldr; do cd $dep; ./autogen.sh && ./configure && sudo make -j4 install; cd ..; done
 
 test:
   pre:
-    - ./autogen.sh && ./configure --enable-coverage --with-valhalla-midgard=/usr/local --with-valhalla-baldr=/usr/local
+    - ./autogen.sh && ./configure --enable-coverage --with-valhalla-midgard=/usr/local --with-valhalla-baldr=/usr/local CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE
   override:
-    - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib make test -j4
+    - make test -j4
   post:
     - sudo make install
 

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ checkout:
 dependencies:
   override:
     - sudo apt-get remove --purge -y libboost*
-    - sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev lcov protobuf-compiler libprotobuf-dev
+    - sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev libboost-thread1.54-dev lcov protobuf-compiler libprotobuf-dev
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
     - scripts/install_service_deps.sh
     #valhalla dependencies

--- a/configure.ac
+++ b/configure.ac
@@ -32,10 +32,11 @@ REQUIRE_PROTOC
 AX_BOOST_BASE([1.54], , [AC_MSG_ERROR([cannot find Boost libraries, which are are required for building odin. Please install libboost-dev.])])
 AX_BOOST_PROGRAM_OPTIONS
 AX_BOOST_SYSTEM
+AX_BOOST_THREAD
 AX_BOOST_FILESYSTEM
 
-# check pkg-config packaged packages.
-PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0])
+# check pkg-config dependencies
+PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0 libzmq >= 4.0 libprime_server >= 0.1.0])
 
 # optionally enable coverage information
 CHECK_COVERAGE

--- a/m4/ax_boost_thread.m4
+++ b/m4/ax_boost_thread.m4
@@ -1,0 +1,149 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_THREAD
+#
+# DESCRIPTION
+#
+#   Test for Thread library from the Boost C++ libraries. The macro requires
+#   a preceding call to AX_BOOST_BASE. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_THREAD_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_THREAD
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Michael Tindal
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 27
+
+AC_DEFUN([AX_BOOST_THREAD],
+[
+	AC_ARG_WITH([boost-thread],
+	AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
+                   [use the Thread library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-thread=boost_thread-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+			want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_thread_lib=""
+        else
+		    want_boost="yes"
+		ax_boost_user_thread_lib="$withval"
+		fi
+        ],
+        [want_boost="yes"]
+	)
+
+	if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+        AC_REQUIRE([AC_CANONICAL_BUILD])
+		CPPFLAGS_SAVED="$CPPFLAGS"
+		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+		export CPPFLAGS
+
+		LDFLAGS_SAVED="$LDFLAGS"
+		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+		export LDFLAGS
+
+        AC_CACHE_CHECK(whether the Boost::Thread library is available,
+					   ax_cv_boost_thread,
+        [AC_LANG_PUSH([C++])
+			 CXXFLAGS_SAVE=$CXXFLAGS
+
+			 if test "x$host_os" = "xsolaris" ; then
+				 CXXFLAGS="-pthreads $CXXFLAGS"
+			 elif test "x$host_os" = "xmingw32" ; then
+				 CXXFLAGS="-mthreads $CXXFLAGS"
+			 else
+				CXXFLAGS="-pthread $CXXFLAGS"
+			 fi
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/thread/thread.hpp>]],
+                                   [[boost::thread_group thrds;
+                                   return 0;]])],
+                   ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
+			 CXXFLAGS=$CXXFLAGS_SAVE
+             AC_LANG_POP([C++])
+		])
+		if test "x$ax_cv_boost_thread" = "xyes"; then
+           if test "x$host_os" = "xsolaris" ; then
+			  BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
+		   elif test "x$host_os" = "xmingw32" ; then
+			  BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
+		   else
+			  BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
+		   fi
+
+			AC_SUBST(BOOST_CPPFLAGS)
+
+			AC_DEFINE(HAVE_BOOST_THREAD,,[define if the Boost::Thread library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+
+			LDFLAGS_SAVE=$LDFLAGS
+                        case "x$host_os" in
+                          *bsd* )
+                               LDFLAGS="-pthread $LDFLAGS"
+                          break;
+                          ;;
+                        esac
+            if test "x$ax_boost_user_thread_lib" = "x"; then
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+				done
+                if test "x$link_thread" != "xyes"; then
+                for libextension in `ls -r $BOOSTLIBDIR/boost_thread* 2>/dev/null | sed 's,.*/,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+				done
+                fi
+
+            else
+               for ax_lib in $ax_boost_user_thread_lib boost_thread-$ax_boost_user_thread_lib; do
+				      AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                   [link_thread="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+			if test "x$link_thread" = "xno"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+                        else
+                           case "x$host_os" in
+                              *bsd* )
+				BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
+                              break;
+                              ;;
+                           esac
+
+			fi
+		fi
+
+		CPPFLAGS="$CPPFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
+	fi
+])

--- a/scripts/install_service_deps.sh
+++ b/scripts/install_service_deps.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# grab the latest zmq library:
+git clone --depth=1 --recurse-submodules --single-branch --branch=master https://github.com/zeromq/libzmq.git
+pushd libzmq
+./autogen.sh && ./configure --without-libsodium --without-documentation && make -j4
+sudo make install
+popd
+rm -rf libzmq
+
+# grab experimental zmq-based server API:
+git clone --depth=1 --recurse-submodules --single-branch --branch=master https://github.com/kevinkreiser/prime_server.git
+pushd prime_server
+./autogen.sh && ./configure && make test -j4
+sudo make install
+popd
+rm -rf prime_server

--- a/src/odin/odin_service.cc
+++ b/src/odin/odin_service.cc
@@ -1,0 +1,24 @@
+#include <iostream>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include "odin/service.h"
+
+int main(int argc, char** argv) {
+
+  if(argc < 2) {
+    std::cerr << "Usage: " << std::string(argv[0]) << " conf/valhalla.json" << std::endl;
+    return 1;
+  }
+
+  //config file
+  std::string config_file(argv[1]);
+  boost::property_tree::ptree config;
+  boost::property_tree::read_json(config_file, config);
+
+  //run the service worker
+  valhalla::odin::run_service(config);
+
+  return 0;
+}

--- a/src/odin/service.cc
+++ b/src/odin/service.cc
@@ -1,0 +1,94 @@
+#include <functional>
+#include <string>
+#include <stdexcept>
+#include <vector>
+#include <unordered_map>
+#include <cstdint>
+#include <sstream>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/info_parser.hpp>
+
+#include <prime_server/prime_server.hpp>
+#include <prime_server/http_protocol.hpp>
+using namespace prime_server;
+
+#include <valhalla/midgard/logging.h>
+
+#include "odin/service.h"
+#include "odin/util.h"
+#include "proto/directions_options.pb.h"
+#include "proto/trippath.pb.h"
+#include "odin/directionsbuilder.h"
+
+using namespace valhalla;
+using namespace valhalla::midgard;
+using namespace valhalla::baldr;
+
+namespace {
+  //TODO: throw this in the header to make it testable?
+  class odin_worker_t {
+   public:
+    odin_worker_t(const boost::property_tree::ptree& config):config(config) {
+
+    }
+    worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info) {
+      try{
+        //crack open the original request
+        std::string request_str(static_cast<const char*>(job.front().data()), job.front().size());
+        std::stringstream stream(request_str);
+        boost::property_tree::ptree request;
+        boost::property_tree::read_info(stream, request);
+
+        //see if we can get some options
+        valhalla::odin::DirectionsOptions directions_options;
+        auto options = request.get_child_optional("directions_options");
+        if(options)
+          directions_options = valhalla::odin::GetDirectionsOptions(*options);
+
+        //crack open the path
+        odin::TripPath trip_path;
+        trip_path.ParseFromArray(job.back().data(), static_cast<int>(job.back().size()));
+
+        //get some annotated directions
+        odin::DirectionsBuilder directions;
+        odin::TripDirections trip_directions = directions.Build(directions_options, trip_path);
+
+        //pass it on
+        worker_t::result_t result{true};
+        result.messages.emplace_back(std::move(request_str)); //the original request
+        result.messages.emplace_back(trip_directions.SerializeAsString()); //the protobuf directions
+        return result;
+      }
+      catch(const std::exception& e) {
+        worker_t::result_t result{false};
+        http_response_t response(400, "Bad Request", e.what());
+        response.from_info(static_cast<http_request_t::info_t*>(request_info));
+        result.messages.emplace_back(response.to_string());
+        return result;
+      }
+    }
+   protected:
+    boost::property_tree::ptree config;
+  };
+}
+
+namespace valhalla {
+  namespace odin {
+    void run_service(const boost::property_tree::ptree& config) {
+      //gets requests from odin proxy
+      auto upstream_endpoint = config.get<std::string>("odin.service.proxy") + "_out";
+      //sends them on to tyr
+      auto downstream_endpoint = config.get<std::string>("tyr.service.proxy") + "_in";
+      //or returns just location information back to the server
+      auto loopback_endpoint = config.get<std::string>("httpd.service.loopback");
+
+      //listen for requests
+      zmq::context_t context;
+      prime_server::worker_t worker(context, upstream_endpoint, downstream_endpoint, loopback_endpoint,
+        std::bind(&odin_worker_t::work, odin_worker_t(config), std::placeholders::_1, std::placeholders::_2));
+      worker.work();
+
+      //TODO: should we listen for SIGINT and terminate gracefully/exit(0)?
+    }
+  }
+}

--- a/valhalla/odin/service.h
+++ b/valhalla/odin/service.h
@@ -1,0 +1,15 @@
+#ifndef __VALHALLA_ODIN_SERVICE_H__
+#define __VALHALLA_ODIN_SERVICE_H__
+
+#include <boost/property_tree/ptree.hpp>
+
+namespace valhalla {
+  namespace odin {
+
+    void run_service(const boost::property_tree::ptree& config);
+
+  }
+}
+
+
+#endif //__VALHALLA_ODIN_SERVICE_H__


### PR DESCRIPTION
two things are added here, a binary that makes use of the odin service layer code, and the odin service layer code with is part of the odin library. it makes use of all the prime_server zmq deps but its part of the library so the simple server in tyr can just use it. this way the same code will be run regardless of in production or testing on our local machines

for odin it was really straight forward, grab some info out of the request that thor passes on to us (hopefully narrative options etc). recontitute the trip_path protobuf from bytes, make directions protobuf, serialize the protobuf bytes (and the original request) onto tyr.
