### PR TITLE
For exit sign info - added capability to have max item count per exit…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,7 @@ test/maneuversbuilder
 test/narrativebuilder
 test/enhancedtrippath
 test/sign
-test/streetname
-test/streetnames
+test/signs
 test/*.log
 test/*.trs
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,8 @@ check_PROGRAMS = \
 	test/maneuversbuilder \
 	test/narrativebuilder \
 	test/enhancedtrippath \
-	test/sign 
+	test/sign \
+	test/signs 
 test_maneuversbuilder_SOURCES = test/maneuversbuilder.cc test/test.cc
 test_maneuversbuilder_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 test_maneuversbuilder_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_odin.la
@@ -101,9 +102,9 @@ test_enhancedtrippath_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ l
 test_sign_SOURCES = test/sign.cc test/test.cc
 test_sign_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 test_sign_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_odin.la
-test_streetnames_SOURCES = test/streetnames.cc test/test.cc
-test_streetnames_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-test_streetnames_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_odin.la
+test_signs_SOURCES = test/signs.cc test/test.cc
+test_signs_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
+test_signs_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_odin.la
 
 TESTS = $(check_PROGRAMS)
 TEST_EXTENSIONS = .sh

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -219,6 +219,16 @@ void NarrativeBuilder::FormRampStraightInstruction(Maneuver& maneuver) {
   // 3 Stay straight to take the I 95 South ramp toward Baltimore
   // 4 Stay straight to take the Gettysburg Pike ramp
 
+  // TODO: determine if we want to grab from options
+  uint32_t number_max_count = 0;
+  uint32_t branch_max_count = 4;
+  uint32_t toward_max_count = 4;
+  uint32_t name_max_count = 4;
+  bool number_limit_by_consecutive_count = false;
+  bool branch_limit_by_consecutive_count = true;
+  bool toward_limit_by_consecutive_count = true;
+  bool name_limit_by_consecutive_count = true;
+
   std::string text_instruction;
   text_instruction.reserve(kTextInstructionInitialCapacity);
   uint8_t phrase_id = 0;
@@ -235,29 +245,29 @@ void NarrativeBuilder::FormRampStraightInstruction(Maneuver& maneuver) {
     // 1 Stay straight to take the I 95 South ramp
     case 1: {
       text_instruction += (boost::format("Stay straight to take the %1% ramp")
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 2 Stay straight to take the ramp toward Baltimore
     case 2: {
       text_instruction += (boost::format(
           "Stay straight to take the ramp toward %1%")
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 3 Stay straight to take the I 95 South ramp toward Baltimore
     case 3: {
       text_instruction += (boost::format(
           "Stay straight to take the %1% ramp toward %2%")
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 4 Stay straight to take the Gettysburg Pike ramp
     case 4: {
       text_instruction += (boost::format(
           "Stay straight to take the %1% ramp")
-          % maneuver.signs().GetExitNameString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)).str();
       break;
     }
     default: {
@@ -288,6 +298,16 @@ void NarrativeBuilder::FormRampRightInstruction(Maneuver& maneuver) {
   // 11 Turn right to take the I 95 South ramp toward Baltimore
   // 12 Turn right to take the Gettysburg Pike ramp
 
+  // TODO: determine if we want to grab from options
+  uint32_t number_max_count = 0;
+  uint32_t branch_max_count = 4;
+  uint32_t toward_max_count = 4;
+  uint32_t name_max_count = 4;
+  bool number_limit_by_consecutive_count = false;
+  bool branch_limit_by_consecutive_count = true;
+  bool toward_limit_by_consecutive_count = true;
+  bool name_limit_by_consecutive_count = true;
+
   std::string text_instruction;
   text_instruction.reserve(kTextInstructionInitialCapacity);
   uint8_t phrase_id = 0;
@@ -306,28 +326,28 @@ void NarrativeBuilder::FormRampRightInstruction(Maneuver& maneuver) {
     // 1 Take the I 95 South ramp on the right
     case 1: {
       text_instruction += (boost::format("Take the %1% ramp on the right")
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 2 Take the ramp on the right toward Baltimore
     case 2: {
       text_instruction += (boost::format(
           "Take the ramp on the right toward %1%")
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 3 Take the I 95 South ramp on the right toward Baltimore
     case 3: {
       text_instruction += (boost::format(
           "Take the %1% ramp on the right toward %2%")
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 4 Take the Gettysburg Pike ramp on the right
     case 4: {
       text_instruction += (boost::format("Take the %1% ramp on the right")
-          % maneuver.signs().GetExitNameString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)).str();
       break;
     }
       // 8 Turn right to take the ramp
@@ -338,28 +358,28 @@ void NarrativeBuilder::FormRampRightInstruction(Maneuver& maneuver) {
       // 9 Turn right to take the I 95 South ramp
     case 9: {
       text_instruction += (boost::format("Turn right to take the %1% ramp")
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 10 Turn right to take the ramp toward Baltimore
     case 10: {
       text_instruction += (boost::format(
           "Turn right to take the ramp toward %1%")
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 11 Turn right to take the I 95 South ramp toward Baltimore
     case 11: {
       text_instruction += (boost::format(
           "Turn right to take the %1% ramp toward %2%")
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 12 Turn right to take the Gettysburg Pike ramp
     case 12: {
       text_instruction += (boost::format("Turn right to take the %1% ramp")
-          % maneuver.signs().GetExitNameString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)).str();
       break;
     }
     default: {
@@ -391,6 +411,16 @@ void NarrativeBuilder::FormRampLeftInstruction(Maneuver& maneuver) {
   // 11 Turn left to take the I 95 South ramp toward Baltimore
   // 12 Turn left to take the Gettysburg Pike ramp
 
+  // TODO: determine if we want to grab from options
+  uint32_t number_max_count = 0;
+  uint32_t branch_max_count = 4;
+  uint32_t toward_max_count = 4;
+  uint32_t name_max_count = 4;
+  bool number_limit_by_consecutive_count = false;
+  bool branch_limit_by_consecutive_count = true;
+  bool toward_limit_by_consecutive_count = true;
+  bool name_limit_by_consecutive_count = true;
+
   std::string text_instruction;
   text_instruction.reserve(kTextInstructionInitialCapacity);
   uint8_t phrase_id = 0;
@@ -409,27 +439,27 @@ void NarrativeBuilder::FormRampLeftInstruction(Maneuver& maneuver) {
     // 1 Take the I 95 South ramp on the left
     case 1: {
       text_instruction += (boost::format("Take the %1% ramp on the left")
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 2 Take the ramp on the left toward Baltimore
     case 2: {
       text_instruction += (boost::format("Take the ramp on the left toward %1%")
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 3 Take the I 95 South ramp on the left toward Baltimore
     case 3: {
       text_instruction += (boost::format(
           "Take the %1% ramp on the left toward %2%")
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 4 Take the Gettysburg Pike ramp on the left
     case 4: {
       text_instruction += (boost::format("Take the %1% ramp on the left")
-          % maneuver.signs().GetExitNameString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)).str();
       break;
     }
       // 8 Turn left to take the ramp
@@ -440,28 +470,28 @@ void NarrativeBuilder::FormRampLeftInstruction(Maneuver& maneuver) {
       // 9 Turn left to take the I 95 South ramp
     case 9: {
       text_instruction += (boost::format("Turn left to take the %1% ramp")
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 10 Turn left to take the ramp toward Baltimore
     case 10: {
       text_instruction += (boost::format(
           "Turn left to take the ramp toward %1%")
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 11 Turn left to take the I 95 South ramp toward Baltimore
     case 11: {
       text_instruction += (boost::format(
           "Turn left to take the %1% ramp toward %2%")
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 12 Turn left to take the Gettysburg Pike ramp
     case 12: {
       text_instruction += (boost::format("Turn left to take the %1% ramp")
-          % maneuver.signs().GetExitNameString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)).str();
       break;
     }
     default: {
@@ -497,6 +527,16 @@ void NarrativeBuilder::FormExitRightInstruction(Maneuver& maneuver) {
   // 12 Take the Gettysburg Pike exit on the right toward Harrisburg/Gettysburg
   // 14 Take the Gettysburg Pike exit on the right onto US 15 toward Harrisburg/Gettysburg
 
+  // TODO: determine if we want to grab from options
+  uint32_t number_max_count = 0;
+  uint32_t branch_max_count = 4;
+  uint32_t toward_max_count = 4;
+  uint32_t name_max_count = 4;
+  bool number_limit_by_consecutive_count = false;
+  bool branch_limit_by_consecutive_count = true;
+  bool toward_limit_by_consecutive_count = true;
+  bool name_limit_by_consecutive_count = true;
+
   std::string text_instruction;
   text_instruction.reserve(kTextInstructionInitialCapacity);
   uint8_t phrase_id = 0;
@@ -514,83 +554,83 @@ void NarrativeBuilder::FormExitRightInstruction(Maneuver& maneuver) {
     // 1 Take exit 67A on the right
     case 1: {
       text_instruction += (boost::format("Take exit %1% on the right")
-          % maneuver.signs().GetExitNumberString()).str();
+          % maneuver.signs().GetExitNumberString(number_max_count, number_limit_by_consecutive_count)).str();
       break;
     }
       // 2 Take the I 95 South exit on the right
     case 2: {
       text_instruction += (boost::format("Take the %1% exit on the right")
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 3 Take exit 67A on the right onto I 95 South
     case 3: {
       text_instruction += (boost::format("Take exit %1% on the right onto %2%")
-          % maneuver.signs().GetExitNumberString()
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitNumberString(number_max_count, number_limit_by_consecutive_count)
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 4 Take the exit on the right toward Baltimore
     case 4: {
       text_instruction += (boost::format(
           "Take the exit on the right toward %1%")
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 5 Take exit 67A on the right toward Baltimore
     case 5: {
       text_instruction += (boost::format(
           "Take exit %1% on the right toward %2%")
-          % maneuver.signs().GetExitNumberString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitNumberString(number_max_count, number_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 6 Take the I 95 South exit on the right toward Baltimore
     case 6: {
       text_instruction += (boost::format(
           "Take the %1% exit on the right toward %2%")
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 7 Take exit 67A on the right onto I 95 South toward Baltimore
     case 7: {
       text_instruction += (boost::format(
           "Take exit %1% on the right onto %2% toward %3%")
-          % maneuver.signs().GetExitNumberString()
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitNumberString(number_max_count, number_limit_by_consecutive_count)
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 8 Take the Gettysburg Pike exit on the right
     case 8: {
       text_instruction += (boost::format("Take the %1% exit on the right")
-          % maneuver.signs().GetExitNameString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)).str();
       break;
     }
       // 10 Take the Gettysburg Pike exit on the right onto US 15
     case 10: {
       text_instruction += (boost::format(
           "Take the %1% exit on the right onto %2%")
-          % maneuver.signs().GetExitNameString()
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 12 Take the Gettysburg Pike exit on the right toward Harrisburg/Gettysburg
     case 12: {
       text_instruction += (boost::format(
           "Take the %1% exit on the right toward %2%")
-          % maneuver.signs().GetExitNameString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 14 Take the Gettysburg Pike exit on the right onto US 15 toward Harrisburg/Gettysburg
     case 14: {
       text_instruction += (boost::format(
           "Take the %1% exit on the right onto %2% toward %3%")
-          % maneuver.signs().GetExitNameString()
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
     default: {
@@ -610,6 +650,16 @@ void NarrativeBuilder::FormExitLeftInstruction(Maneuver& maneuver) {
   // 4 = toward
   // 8 = name (when no number)
 
+  // TODO: determine if we want to grab from options
+  uint32_t number_max_count = 0;
+  uint32_t branch_max_count = 4;
+  uint32_t toward_max_count = 4;
+  uint32_t name_max_count = 4;
+  bool number_limit_by_consecutive_count = false;
+  bool branch_limit_by_consecutive_count = true;
+  bool toward_limit_by_consecutive_count = true;
+  bool name_limit_by_consecutive_count = true;
+
   std::string text_instruction;
   text_instruction.reserve(kTextInstructionInitialCapacity);
   uint8_t phrase_id = 0;
@@ -627,81 +677,81 @@ void NarrativeBuilder::FormExitLeftInstruction(Maneuver& maneuver) {
     // 1 Take exit 67A on the left
     case 1: {
       text_instruction += (boost::format("Take exit %1% on the left")
-          % maneuver.signs().GetExitNumberString()).str();
+          % maneuver.signs().GetExitNumberString(number_max_count, number_limit_by_consecutive_count)).str();
       break;
     }
       // 2 Take the I 95 South exit on the left
     case 2: {
       text_instruction += (boost::format("Take the %1% exit on the left")
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 3 Take exit 67A on the left onto I 95 South
     case 3: {
       text_instruction += (boost::format("Take exit %1% on the left onto %2%")
-          % maneuver.signs().GetExitNumberString()
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitNumberString(number_max_count, number_limit_by_consecutive_count)
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 4 Take the exit on the left toward Baltimore
     case 4: {
       text_instruction += (boost::format("Take the exit on the left toward %1%")
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 5 Take exit 67A on the left toward Baltimore
     case 5: {
       text_instruction += (boost::format("Take exit %1% on the left toward %2%")
-          % maneuver.signs().GetExitNumberString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitNumberString(number_max_count, number_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 6 Take the I 95 South exit on the left toward Baltimore
     case 6: {
       text_instruction += (boost::format(
           "Take the %1% exit on the left toward %2%")
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 7 Take exit 67A on the left onto I 95 South toward Baltimore
     case 7: {
       text_instruction += (boost::format(
           "Take exit %1% on the left onto %2% toward %3%")
-          % maneuver.signs().GetExitNumberString()
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitNumberString(number_max_count, number_limit_by_consecutive_count)
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 8 Take the Gettysburg Pike exit on the left
     case 8: {
       text_instruction += (boost::format("Take the %1% exit on the left")
-          % maneuver.signs().GetExitNameString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)).str();
       break;
     }
       // 10 Take the Gettysburg Pike exit on the left onto US 15
     case 10: {
       text_instruction += (boost::format(
           "Take the %1% exit on the left onto %2%")
-          % maneuver.signs().GetExitNameString()
-          % maneuver.signs().GetExitBranchString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)).str();
       break;
     }
       // 12 Take the Gettysburg Pike exit on the left toward Harrisburg/Gettysburg
     case 12: {
       text_instruction += (boost::format(
           "Take the %1% exit on the left toward %2%")
-          % maneuver.signs().GetExitNameString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
       // 14 Take the Gettysburg Pike exit on the left onto US 15 toward Harrisburg/Gettysburg
     case 14: {
       text_instruction += (boost::format(
           "Take the %1% exit on the left onto %2% toward %3%")
-          % maneuver.signs().GetExitNameString()
-          % maneuver.signs().GetExitBranchString()
-          % maneuver.signs().GetExitTowardString()).str();
+          % maneuver.signs().GetExitNameString(name_max_count, name_limit_by_consecutive_count)
+          % maneuver.signs().GetExitBranchString(branch_max_count, branch_limit_by_consecutive_count)
+          % maneuver.signs().GetExitTowardString(toward_max_count, toward_limit_by_consecutive_count)).str();
       break;
     }
     default: {

--- a/src/odin/signs.cc
+++ b/src/odin/signs.cc
@@ -14,8 +14,9 @@ std::vector<Sign>* Signs::mutable_exit_number_list() {
   return &exit_number_list_;
 }
 
-const std::string Signs::GetExitNumberString() const {
-  return ListToString(exit_number_list_);
+const std::string Signs::GetExitNumberString(
+    uint32_t max_count, bool limit_by_consecutive_count) const {
+  return ListToString(exit_number_list_, max_count, limit_by_consecutive_count);
 }
 
 const std::vector<Sign>& Signs::exit_branch_list() const {
@@ -26,8 +27,9 @@ std::vector<Sign>* Signs::mutable_exit_branch_list() {
   return &exit_branch_list_;
 }
 
-const std::string Signs::GetExitBranchString() const {
-  return ListToString(exit_branch_list_);
+const std::string Signs::GetExitBranchString(
+    uint32_t max_count, bool limit_by_consecutive_count) const {
+  return ListToString(exit_branch_list_, max_count, limit_by_consecutive_count);
 }
 
 const std::vector<Sign>& Signs::exit_toward_list() const {
@@ -38,8 +40,9 @@ std::vector<Sign>* Signs::mutable_exit_toward_list() {
   return &exit_toward_list_;
 }
 
-const std::string Signs::GetExitTowardString() const {
-  return ListToString(exit_toward_list_);
+const std::string Signs::GetExitTowardString(
+    uint32_t max_count, bool limit_by_consecutive_count) const {
+  return ListToString(exit_toward_list_, max_count, limit_by_consecutive_count);
 }
 
 const std::vector<Sign>& Signs::exit_name_list() const {
@@ -50,8 +53,9 @@ std::vector<Sign>* Signs::mutable_exit_name_list() {
   return &exit_name_list_;
 }
 
-const std::string Signs::GetExitNameString() const {
-  return ListToString(exit_name_list_);
+const std::string Signs::GetExitNameString(
+    uint32_t max_count, bool limit_by_consecutive_count) const {
+  return ListToString(exit_name_list_, max_count, limit_by_consecutive_count);
 }
 
 bool Signs::HasExit() const {
@@ -111,14 +115,44 @@ std::string Signs::ToParameterString() const {
   return signs_string;
 }
 
-const std::string Signs::ListToString(const std::vector<Sign>& signs) const {
+const std::string Signs::ListToString(const std::vector<Sign>& signs,
+                                      uint32_t max_count,
+                                      bool limit_by_consecutive_count) const {
   std::string sign_string;
+  uint32_t count = 0;
+  uint32_t consecutive_count = -1;
+
   for (auto& sign : signs) {
+    // If supplied, limit by max count
+    if ((max_count > 0) && (count == max_count)) {
+      break;
+    }
+
+    // if requested, process consecutive exit counts
+    if (limit_by_consecutive_count) {
+
+      // Set consecutive count if first sign
+      if (count == 0) {
+        consecutive_count = sign.consecutive_count();
+      }
+      // Limit if consecutive count does not match
+      // Therefore, the most consistent information is displayed for user
+      // and reduces clutter
+      else if (sign.consecutive_count() != consecutive_count) {
+        break;
+      }
+    }
+
+    // Add delimiter
     if (!sign_string.empty()) {
       sign_string += "/";
     }
+
+    // Concatenate exit text and update count
     sign_string += sign.text();
+    ++count;
   }
+
   return sign_string;
 }
 

--- a/test/signs.cc
+++ b/test/signs.cc
@@ -1,0 +1,228 @@
+#include "test.h"
+#include "valhalla/odin/sign.h"
+#include "valhalla/odin/signs.h"
+
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+using namespace valhalla::odin;
+
+namespace {
+
+void PopulateSigns(const std::vector<std::string>& sign_text_list,
+                   const std::vector<int>& consecutive_count_list,
+                   std::vector<Sign>* sign_list) {
+  if (sign_text_list.size() != consecutive_count_list.size())
+    throw std::runtime_error("Invalid test input");
+
+  for (auto& sign_text : sign_text_list) {
+    sign_list->emplace_back(sign_text);
+  }
+
+  int i = 0;
+  for (auto& consecutive_count : consecutive_count_list) {
+    sign_list->at(i++).set_consecutive_count(
+        consecutive_count);
+  }
+
+}
+
+Signs GetNumberSigns(const std::vector<std::string>& sign_text_list,
+               const std::vector<int>& consecutive_count_list) {
+  if (sign_text_list.size() != consecutive_count_list.size())
+    throw std::runtime_error("Invalid test input");
+
+  Signs signs;
+  PopulateSigns(sign_text_list, consecutive_count_list,
+                signs.mutable_exit_number_list());
+
+    return signs;
+}
+
+Signs GetBranchSigns(const std::vector<std::string>& sign_text_list,
+               const std::vector<int>& consecutive_count_list) {
+  if (sign_text_list.size() != consecutive_count_list.size())
+    throw std::runtime_error("Invalid test input");
+
+  Signs signs;
+  PopulateSigns(sign_text_list, consecutive_count_list,
+                signs.mutable_exit_branch_list());
+
+    return signs;
+}
+
+Signs GetTowardSigns(const std::vector<std::string>& sign_text_list,
+               const std::vector<int>& consecutive_count_list) {
+  if (sign_text_list.size() != consecutive_count_list.size())
+    throw std::runtime_error("Invalid test input");
+
+  Signs signs;
+  PopulateSigns(sign_text_list, consecutive_count_list,
+                signs.mutable_exit_toward_list());
+
+    return signs;
+}
+
+Signs GetNameSigns(const std::vector<std::string>& sign_text_list,
+               const std::vector<int>& consecutive_count_list) {
+  if (sign_text_list.size() != consecutive_count_list.size())
+    throw std::runtime_error("Invalid test input");
+
+  Signs signs;
+  PopulateSigns(sign_text_list, consecutive_count_list,
+                signs.mutable_exit_name_list());
+
+    return signs;
+}
+
+void TryGetExitNumberString(const Signs& signs, uint32_t max_count,
+                            bool limit_by_consecutive_count,
+                            const std::string& expectedString) {
+
+  if (signs.GetExitNumberString(max_count, limit_by_consecutive_count)
+      != expectedString) {
+    throw std::runtime_error(
+        "Incorrect Exit Number String - expected: " + expectedString);
+  }
+}
+
+void TryGetExitBranchString(const Signs& signs, uint32_t max_count,
+                            bool limit_by_consecutive_count,
+                            const std::string& expectedString) {
+
+  if (signs.GetExitBranchString(max_count, limit_by_consecutive_count)
+      != expectedString) {
+    throw std::runtime_error(
+        "Incorrect Exit Branch String - expected: " + expectedString);
+  }
+}
+
+void TryGetExitTowardString(const Signs& signs, uint32_t max_count,
+                            bool limit_by_consecutive_count,
+                            const std::string& expectedString) {
+
+  if (signs.GetExitTowardString(max_count, limit_by_consecutive_count)
+      != expectedString) {
+    throw std::runtime_error(
+        "Incorrect Exit Toward String - expected: " + expectedString);
+  }
+}
+
+void TryGetExitNameString(const Signs& signs, uint32_t max_count,
+                            bool limit_by_consecutive_count,
+                            const std::string& expectedString) {
+
+  if (signs.GetExitNameString(max_count, limit_by_consecutive_count)
+      != expectedString) {
+    throw std::runtime_error(
+        "Incorrect Exit Name String - expected: " + expectedString);
+  }
+}
+
+void TestGetExitTowardString_PA283_onto_PA743() {
+  // Create toward sign
+  // Specify input in descending consecutive count order
+  Signs signs = GetTowardSigns(
+      { "Elizabethtown", "Hershey" },
+      { 1, 0} );
+
+  TryGetExitTowardString(signs, 4, false, "Elizabethtown/Hershey");
+  TryGetExitTowardString(signs, 2, false, "Elizabethtown/Hershey");
+  TryGetExitTowardString(signs, 1, false, "Elizabethtown");
+
+  TryGetExitTowardString(signs, 2, true, "Elizabethtown");
+  TryGetExitTowardString(signs, 1, true, "Elizabethtown");
+}
+
+void TestGetExitNumberString_I81S_onto_US322W() {
+  // Create number sign
+  // Specify input in descending consecutive count order
+  Signs signs = GetNumberSigns(
+      { "67B", "67A" },
+      { 1, 0 } );
+
+  TryGetExitNumberString(signs, 4, false, "67B/67A");
+  TryGetExitNumberString(signs, 2, false, "67B/67A");
+  TryGetExitNumberString(signs, 1, false, "67B");
+
+  TryGetExitNumberString(signs, 4, true, "67B");
+  TryGetExitNumberString(signs, 2, true, "67B");
+  TryGetExitNumberString(signs, 1, true, "67B");
+}
+
+void TestGetExitBranchString_I81S_onto_US322W() {
+  // Create branch sign
+  // Specify input in descending consecutive count order
+  Signs signs = GetBranchSigns(
+      { "US 322 West", "US 22 West", "US 22 East", "PA 230 East", "Cameron Street" },
+      { 2, 1, 0, 0, 0 } );
+
+  TryGetExitBranchString(signs, 0, false, "US 322 West/US 22 West/US 22 East/PA 230 East/Cameron Street");
+  TryGetExitBranchString(signs, 5, false, "US 322 West/US 22 West/US 22 East/PA 230 East/Cameron Street");
+  TryGetExitBranchString(signs, 4, false, "US 322 West/US 22 West/US 22 East/PA 230 East");
+  TryGetExitBranchString(signs, 2, false, "US 322 West/US 22 West");
+  TryGetExitBranchString(signs, 1, false, "US 322 West");
+
+  TryGetExitBranchString(signs, 0, true, "US 322 West");
+  TryGetExitBranchString(signs, 5, true, "US 322 West");
+  TryGetExitBranchString(signs, 4, true, "US 322 West");
+  TryGetExitBranchString(signs, 2, true, "US 322 West");
+  TryGetExitBranchString(signs, 1, true, "US 322 West");
+
+}
+
+void TestGetExitTowardString_I81S_onto_US322W() {
+  // Create toward sign
+  // Specify input in descending consecutive count order
+  Signs signs = GetTowardSigns(
+      { "Lewistown", "State College", "Harrisburg"},
+      { 1, 1, 0 } );
+
+  TryGetExitTowardString(signs, 4, false, "Lewistown/State College/Harrisburg");
+  TryGetExitTowardString(signs, 2, false, "Lewistown/State College");
+  TryGetExitTowardString(signs, 1, false, "Lewistown");
+
+  TryGetExitTowardString(signs, 4, true, "Lewistown/State College");
+  TryGetExitTowardString(signs, 2, true, "Lewistown/State College");
+  TryGetExitTowardString(signs, 1, true, "Lewistown");
+}
+
+void TestGetExitNameString() {
+  // Create name sign
+  // Specify input in descending consecutive count order
+  Signs signs = GetNameSigns(
+      { "Gettysburg Pike", "Harrisburg Pike"},
+      { 1, 0 } );
+
+  TryGetExitNameString(signs, 4, false, "Gettysburg Pike/Harrisburg Pike");
+  TryGetExitNameString(signs, 2, false, "Gettysburg Pike/Harrisburg Pike");
+  TryGetExitNameString(signs, 1, false, "Gettysburg Pike");
+
+  TryGetExitNameString(signs, 4, true, "Gettysburg Pike");
+  TryGetExitNameString(signs, 2, true, "Gettysburg Pike");
+  TryGetExitNameString(signs, 1, true, "Gettysburg Pike");
+}
+
+}
+
+int main() {
+  test::suite suite("signs");
+
+  // GetExitTowardString_PA283_onto_PA743
+  suite.test(TEST_CASE(TestGetExitTowardString_PA283_onto_PA743));
+
+  // GetExitNumberString_I81S_onto_US322W
+  suite.test(TEST_CASE(TestGetExitNumberString_I81S_onto_US322W));
+
+  // GetExitBranchString_I81S_onto_US322W
+  suite.test(TEST_CASE(TestGetExitBranchString_I81S_onto_US322W));
+
+  // GetExitTowardString_I81S_onto_US322W
+  suite.test(TEST_CASE(TestGetExitTowardString_I81S_onto_US322W));
+
+  // GetExitNameString
+  suite.test(TEST_CASE(TestGetExitNameString));
+
+  return suite.tear_down();
+}

--- a/valhalla/odin/signs.h
+++ b/valhalla/odin/signs.h
@@ -17,22 +17,26 @@ class Signs {
   const std::vector<Sign>& exit_number_list() const;
   std::vector<Sign>* mutable_exit_number_list();
 
-  const std::string GetExitNumberString() const;
+  const std::string GetExitNumberString(
+      uint32_t max_count = 0, bool limit_by_consecutive_count = false) const;
 
   const std::vector<Sign>& exit_branch_list() const;
   std::vector<Sign>* mutable_exit_branch_list();
 
-  const std::string GetExitBranchString() const;
+  const std::string GetExitBranchString(
+      uint32_t max_count = 0, bool limit_by_consecutive_count = false) const;
 
   const std::vector<Sign>& exit_toward_list() const;
   std::vector<Sign>* mutable_exit_toward_list();
 
-  const std::string GetExitTowardString() const;
+  const std::string GetExitTowardString(
+      uint32_t max_count = 0, bool limit_by_consecutive_count = false) const;
 
   const std::vector<Sign>& exit_name_list() const;
   std::vector<Sign>* mutable_exit_name_list();
 
-  const std::string GetExitNameString() const;
+  const std::string GetExitNameString(
+      uint32_t max_count = 0, bool limit_by_consecutive_count = false) const;
 
   bool HasExit() const;
   bool HasExitNumber() const;
@@ -47,7 +51,9 @@ class Signs {
   bool operator ==(const Signs& rhs) const;
 
  protected:
-  const std::string ListToString(const std::vector<Sign>& signs) const;
+  const std::string ListToString(const std::vector<Sign>& signs,
+                                 uint32_t max_count = 0,
+                                 bool limit_by_consecutive_count = false) const;
 
   const std::string ListToParameterString(const std::vector<Sign>& signs) const;
 


### PR DESCRIPTION
… number, branch, toward, and name.

Also, added cpability to limit the limit the exit sign info by consecutive count.
This update helps to reduce clutter for the user at key decision points.

Please see the examples below:

Example#1
---------
BEFORE
Take exit 67A-B on the right onto US 322 West/US 22 West/US 22 East/PA 230 East/Cameron Street toward Lewistown/State College/Harrisburg.
Take exit 67B on the right onto US 322 West/US 22 West toward Lewistown/State College.

AFTER
Take exit 67A-B on the right onto US 322 West toward Lewistown/State College.
Take exit 67B on the right onto US 322 West toward Lewistown/State College.

Example#2
---------
BEFORE
Take exit 91B-A on the right onto I 695 South/I 695 North toward I 95 South/Baltimore/Glen Burnie/I 95 North/New York/Towson.

AFTER
Take exit 91B-A on the right onto I 695 South toward I 95 South/Baltimore/Glen Burnie.