### PR TITLE
Added fork functionality to maneuver

### DIFF
--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -492,6 +492,14 @@ void Maneuver::InsertTransitStop(std::string name,
                                             departure_date_time);
 }
 
+bool Maneuver::fork() const {
+  return fork_;
+}
+
+void Maneuver::set_fork(bool fork) {
+  fork_ = fork;
+}
+
 std::string Maneuver::ToString() const {
   std::string man_str;
   man_str.reserve(256);

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -185,6 +185,9 @@ class Maneuver {
   void InsertTransitStop(std::string name, std::string arrival_date_time,
                          std::string departure_date_time);
 
+  bool fork() const;
+  void set_fork(bool fork);
+
   std::string ToString() const;
 
   std::string ToParameterString() const;
@@ -226,6 +229,7 @@ class Maneuver {
   bool rail_;
   bool bus_;
   TransitInfo transit_info_;
+  bool fork_;
 
   // TODO notes
 

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -71,6 +71,9 @@ class ManeuversBuilder {
 
   bool CanManeuverIncludePrevEdge(Maneuver& maneuver, int node_index);
 
+  bool IsFork(int node_index, EnhancedTripPath_Edge* prev_edge,
+              EnhancedTripPath_Edge* curr_edge) const;
+
   bool IsLeftPencilPointUturn(int node_index, EnhancedTripPath_Edge* prev_edge,
                               EnhancedTripPath_Edge* curr_edge) const;
 

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -42,7 +42,11 @@ class NarrativeBuilder {
 
   static void FormExitLeftInstruction(Maneuver& maneuver);
 
-  static void FormStayInstruction(Maneuver& maneuver);
+  static void FormStayStraightInstruction(Maneuver& maneuver);
+
+  static void FormStayRightInstruction(Maneuver& maneuver);
+
+  static void FormStayLeftInstruction(Maneuver& maneuver);
 
   static void FormMergeInstruction(Maneuver& maneuver);
 


### PR DESCRIPTION
Added narrative for TripDirections_Maneuver_Type_kStayStraight, TripDirections_Maneuver_Type_kStayRight, and TripDirections_Maneuver_Type_kStayLeft maneuver types

BEFORE
Continue on I 895 South/Harbor Tunnel Thruway.

AFTER
Keep right to take exit 62 onto I 895 South/Harbor Tunnel Thruway toward Annapolis.

![keeprightontoi895](https://cloud.githubusercontent.com/assets/7515853/8434984/d1428350-1f1c-11e5-9aa4-8d956a3a1691.png)
