### PR TITLE
Added logic to set and display the maneuver begin street name(s) when needed

### DIFF
--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -182,10 +182,17 @@ void NarrativeBuilder::FormStartInstruction(Maneuver& maneuver) {
   text_instruction += "Go ";
   text_instruction += FormCardinalDirection(
       maneuver.begin_cardinal_direction());
-  if (maneuver.HasStreetNames()) {
+
+  if (maneuver.HasBeginStreetNames()) {
+    text_instruction += " on ";
+    text_instruction += maneuver.begin_street_names().ToString();
+    text_instruction += ". Continue on ";
+    text_instruction += maneuver.street_names().ToString();
+  } else if (maneuver.HasStreetNames()) {
     text_instruction += " on ";
     text_instruction += maneuver.street_names().ToString();
   }
+
   // TODO - side of street
 
   text_instruction += ".";
@@ -252,7 +259,12 @@ void NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver) {
   text_instruction += "Turn ";
   text_instruction += FormTurnTypeInstruction(maneuver.type());
 
-  if (maneuver.HasStreetNames()) {
+  if (maneuver.HasBeginStreetNames()) {
+    text_instruction += " onto ";
+    text_instruction += maneuver.begin_street_names().ToString();
+    text_instruction += ". Continue on ";
+    text_instruction += maneuver.street_names().ToString();
+  } else if (maneuver.HasStreetNames()) {
     text_instruction += " onto ";
     text_instruction += maneuver.street_names().ToString();
   }
@@ -282,7 +294,12 @@ void NarrativeBuilder::FormBearInstruction(Maneuver& maneuver) {
   text_instruction += "Bear ";
   text_instruction += FormBearTypeInstruction(maneuver.type());
 
-  if (maneuver.HasStreetNames()) {
+  if (maneuver.HasBeginStreetNames()) {
+    text_instruction += " onto ";
+    text_instruction += maneuver.begin_street_names().ToString();
+    text_instruction += ". Continue on ";
+    text_instruction += maneuver.street_names().ToString();
+  } else if (maneuver.HasStreetNames()) {
     text_instruction += " onto ";
     text_instruction += maneuver.street_names().ToString();
   }
@@ -1405,7 +1422,13 @@ void NarrativeBuilder::FormExitRoundaboutInstruction(Maneuver& maneuver) {
   std::string text_instruction;
   text_instruction.reserve(kTextInstructionInitialCapacity);
   text_instruction += "Exit the roundabout";
-  if (maneuver.HasStreetNames()) {
+
+  if (maneuver.HasBeginStreetNames()) {
+    text_instruction += " onto ";
+    text_instruction += maneuver.begin_street_names().ToString();
+    text_instruction += ". Continue on ";
+    text_instruction += maneuver.street_names().ToString();
+  } else if (maneuver.HasStreetNames()) {
     text_instruction += " onto ";
     text_instruction += maneuver.street_names().ToString();
   }
@@ -1438,7 +1461,13 @@ void NarrativeBuilder::FormExitFerryInstruction(Maneuver& maneuver) {
   text_instruction += "Go ";
   text_instruction += FormCardinalDirection(
       maneuver.begin_cardinal_direction());
-  if (maneuver.HasStreetNames()) {
+
+  if (maneuver.HasBeginStreetNames()) {
+    text_instruction += " on ";
+    text_instruction += maneuver.begin_street_names().ToString();
+    text_instruction += ". Continue on ";
+    text_instruction += maneuver.street_names().ToString();
+  } else if (maneuver.HasStreetNames()) {
     text_instruction += " on ";
     text_instruction += maneuver.street_names().ToString();
   }
@@ -1590,7 +1619,13 @@ void NarrativeBuilder::FormPostTransitConnectionDestinationInstruction(
   text_instruction += "Go ";
   text_instruction += FormCardinalDirection(
       maneuver.begin_cardinal_direction());
-  if (maneuver.HasStreetNames()) {
+
+  if (maneuver.HasBeginStreetNames()) {
+    text_instruction += " on ";
+    text_instruction += maneuver.begin_street_names().ToString();
+    text_instruction += ". Continue on ";
+    text_instruction += maneuver.street_names().ToString();
+  } else if (maneuver.HasStreetNames()) {
     text_instruction += " on ";
     text_instruction += maneuver.street_names().ToString();
   }


### PR DESCRIPTION
EXAMPLE#1
![begin_street_names_1](https://cloud.githubusercontent.com/assets/7515853/8785728/c20e610c-2ef7-11e5-8106-c42d06d39b97.png)

BEFORE
Turn left onto PA 741.
AFTER
Turn left onto Rohrerstown Road/PA 741. Continue on PA 741.


EXAMPLE#2
![begin_street_names_2](https://cloud.githubusercontent.com/assets/7515853/8785752/e025d18e-2ef7-11e5-93e6-36f349e217bb.png)

BEFORE
Turn right onto VA 7.
AFTER
Turn right onto VA 7/Leesburg Pike. Continue on VA 7.
