### PR TITLE
Added verbal instructions for simple turn maneuvers

### DIFF
--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -148,8 +148,26 @@ TripDirections DirectionsBuilder::PopulateTripDirections(
     trip_maneuver->set_begin_heading(maneuver.begin_heading());
     trip_maneuver->set_begin_shape_index(maneuver.begin_shape_index());
     trip_maneuver->set_end_shape_index(maneuver.end_shape_index());
-    trip_maneuver->set_portions_toll(maneuver.portions_toll());
-    trip_maneuver->set_portions_unpaved(maneuver.portions_unpaved());
+    if (maneuver.portions_toll())
+      trip_maneuver->set_portions_toll(maneuver.portions_toll());
+    if (maneuver.portions_unpaved())
+      trip_maneuver->set_portions_unpaved(maneuver.portions_unpaved());
+
+    if (maneuver.HasVerbalTransitionAlertInstruction()) {
+      trip_maneuver->set_verbal_transition_alert_instruction(
+          maneuver.verbal_transition_alert_instruction());
+    }
+
+    if (maneuver.HasVerbalPreTransitionInstruction()) {
+      trip_maneuver->set_verbal_pre_transition_instruction(
+          maneuver.verbal_pre_transition_instruction());
+    }
+
+    if (maneuver.HasVerbalPostTransitionInstruction()) {
+      trip_maneuver->set_verbal_post_transition_instruction(
+          maneuver.verbal_post_transition_instruction());
+    }
+
   }
 
   // Populate summary

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -556,6 +556,10 @@ void Maneuver::set_verbal_transition_alert_instruction(
       verbal_transition_alert_instruction);
 }
 
+bool Maneuver::HasVerbalTransitionAlertInstruction() const {
+  return (!verbal_transition_alert_instruction_.empty());
+}
+
 const std::string& Maneuver::verbal_pre_transition_instruction() const {
   return verbal_pre_transition_instruction_;
 }
@@ -571,6 +575,10 @@ void Maneuver::set_verbal_pre_transition_instruction(
       verbal_pre_transition_instruction);
 }
 
+bool Maneuver::HasVerbalPreTransitionInstruction() const {
+  return (!verbal_pre_transition_instruction_.empty());
+}
+
 const std::string& Maneuver::verbal_post_transition_instruction() const {
   return verbal_post_transition_instruction_;
 }
@@ -584,6 +592,10 @@ void Maneuver::set_verbal_post_transition_instruction(
     std::string&& verbal_post_transition_instruction) {
   verbal_post_transition_instruction_ = std::move(
       verbal_post_transition_instruction);
+}
+
+bool Maneuver::HasVerbalPostTransitionInstruction() const {
+  return (!verbal_post_transition_instruction_.empty());
 }
 
 std::string Maneuver::ToString() const {

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -204,18 +204,21 @@ class Maneuver {
       const std::string& verbal_transition_alert_instruction);
   void set_verbal_transition_alert_instruction(
       std::string&& verbal_transition_alert_instruction);
+  bool HasVerbalTransitionAlertInstruction() const;
 
   const std::string& verbal_pre_transition_instruction() const;
   void set_verbal_pre_transition_instruction(
       const std::string& verbal_pre_transition_instruction);
   void set_verbal_pre_transition_instruction(
       std::string&& verbal_pre_transition_instruction);
+  bool HasVerbalPreTransitionInstruction() const;
 
   const std::string& verbal_post_transition_instruction() const;
   void set_verbal_post_transition_instruction(
       const std::string& verbal_post_transition_instruction);
   void set_verbal_post_transition_instruction(
       std::string&& verbal_post_transition_instruction);
+  bool HasVerbalPostTransitionInstruction() const;
 
   std::string ToString() const;
 

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -29,7 +29,12 @@ class NarrativeBuilder {
 
   static void FormContinueInstruction(Maneuver& maneuver);
 
-  static void FormTurnInstruction(Maneuver& maneuver);
+  static std::string FormTurnInstruction(Maneuver& maneuver);
+
+  static std::string FormVerbalTurnInstruction(
+      Maneuver& maneuver,
+      uint32_t street_name_max_count = 2,
+      std::string delim = ",");
 
   static void FormTurnToStayOnInstruction(Maneuver& maneuver);
 
@@ -84,6 +89,19 @@ class NarrativeBuilder {
   static void FormTransitTransferInstruction(Maneuver& maneuver);
 
   static void FormPostTransitConnectionDestinationInstruction(Maneuver& maneuver);
+
+  static std::string FormVerbalPostTransitionInstruction(
+      Maneuver& maneuver, DirectionsOptions_Units units,
+      bool include_street_names = false, uint32_t street_name_max_count = 2,
+      std::string delim = ",");
+
+  static std::string FormVerbalPostTransitionKilometersInstruction(
+      Maneuver& maneuver, bool include_street_names = false,
+      uint32_t street_name_max_count = 2, std::string delim = ",");
+
+  static std::string FormVerbalPostTransitionMilesInstruction(
+      Maneuver& maneuver, bool include_street_names = false,
+      uint32_t street_name_max_count = 2, std::string delim = ",");
 
   static std::string FormCardinalDirection(
       TripDirections_Maneuver_CardinalDirection cardinal_direction);


### PR DESCRIPTION
Example:
2: Turn right onto North Prince Street/US 222. Continue on US 222. | 3.9 mi
   VERBAL_ALERT: Turn right onto North Prince Street.
   VERBAL_PRE: Turn right onto North Prince Street,US 222.
   VERBAL_POST: Continue on US 222 for 3.9 miles.
