### PR TITLE
use gcc/++4.9

### DIFF
--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -2,9 +2,11 @@
 set -e
 
 export LD_LIBRARY_PATH=.:`cat /etc/ld.so.conf.d/* | grep -v -E "#" | tr "\\n" ":" | sed -e "s/:$//g"`
-sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev libboost-thread1.54-dev lcov protobuf-compiler libprotobuf-dev libcurl4-openssl-dev
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/ubuntu-toolchain-r-test-$(lsb_release -c -s).list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+sudo apt-get install -y autoconf automake libtool make gcc-4.9 g++-4.9 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev libboost-thread1.54-dev lcov protobuf-compiler libprotobuf-dev libcurl4-openssl-dev
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 90
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
 
 #clone async
 mkdir -p deps


### PR DESCRIPTION
the point of this isnt for bleeding edge-ness but rather because regex (which became fully implemented in stl shipped with 4.9) is very useful and so other projects (particularly odin) will probably want to be making use of it.