### PR TITLE
Combine unnamed edges to fix #128

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1281,6 +1281,12 @@ bool ManeuversBuilder::CanManeuverIncludePrevEdge(Maneuver& maneuver,
     return true;
   }
 
+  /////////////////////////////////////////////////////////////////////////////
+  // Process unnamed edges
+  if (!maneuver.HasStreetNames() && prev_edge->IsUnnamed()) {
+    return true;
+  }
+
   return false;
 
 }


### PR DESCRIPTION
Fixes #128 

BEFORE
1: Go east. | 0.2 mi
2: Continue. | 0.0 mi
3: Continue. | 0.0 mi
4: Continue. | 0.0 mi
5: Continue. | 0.0 mi
6: Continue. | 0.0 mi
7: Bear right. | 0.1 mi
8: Continue. | 0.0 mi
9: Continue. | 0.0 mi
10: Bear right. | 0.0 mi
11: Bear right. | 0.1 mi
12: Continue. | 0.1 mi
13: Turn right. | 0.0 mi
14: Bear left. | 0.0 mi
15: Continue. | 0.0 mi
16: Bear left. | 0.0 mi
17: Bear right. | 0.0 mi
18: Bear left. | 0.0 mi
19: Continue. | 0.0 mi
20: Bear left. | 0.0 mi
21: Bear right. | 0.0 mi
22: Continue. | 0.0 mi
23: Continue. | 0.0 mi
24: Continue. | 0.0 mi
25: Enter the roundabout and take the 1st exit. | 0.0 mi
26: Exit the roundabout. | 0.0 mi
27: Bear right. | 0.0 mi
28: Continue. | 0.0 mi
29: You have arrived at your destination. | 0.0 mi

AFTER
1: Go east. | 0.8 mi
2: Enter the roundabout and take the 1st exit. | 0.0 mi
3: Exit the roundabout. | 0.0 mi
4: Continue. | 0.0 mi
5: You have arrived at your destination. | 0.0 mi
