### PR TITLE
Update the verbal intructions for the start and continue maneuver types so app will be less chatty

### DIFF
--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -84,13 +84,11 @@ void NarrativeBuilder::Build(const DirectionsOptions& directions_options,
 
         // Set verbal pre transition instruction
         maneuver.set_verbal_pre_transition_instruction(
-            std::move(FormVerbalContinueInstruction(maneuver)));
-
-        // Set verbal post transition instruction
-        maneuver.set_verbal_post_transition_instruction(
             std::move(
-                FormVerbalPostTransitionInstruction(
-                    maneuver, directions_options.units())));
+                FormVerbalContinueInstruction(maneuver,
+                                              directions_options.units())));
+
+        // NOTE: No verbal post transition instruction
         break;
       }
       case TripDirections_Maneuver_Type_kSlightRight:
@@ -813,13 +811,25 @@ std::string NarrativeBuilder::FormVerbalAlertContinueInstruction(
     Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
   //  "Continue"
   //  "Continue on <STREET_NAMES(1)>."
-  return FormVerbalContinueInstruction(maneuver, element_max_count, delim);
+  std::string instruction;
+  instruction.reserve(kTextInstructionInitialCapacity);
+  instruction += "Continue";
+
+  if (maneuver.HasStreetNames()) {
+    instruction += " on ";
+    instruction += maneuver.street_names().ToString(
+        element_max_count, delim, maneuver.verbal_formatter());
+  }
+
+  instruction += ".";
+  return instruction;
 }
 
 std::string NarrativeBuilder::FormVerbalContinueInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
-  //  "Continue"
-  //  "Continue on <STREET_NAMES(2)>."
+    Maneuver& maneuver, DirectionsOptions_Units units,
+    uint32_t element_max_count, std::string delim) {
+  //  "Continue for <DISTANCE>"
+  //  "Continue on <STREET_NAMES(2)> for <DISTANCE>."
 
   std::string instruction;
   instruction.reserve(kTextInstructionInitialCapacity);
@@ -831,6 +841,8 @@ std::string NarrativeBuilder::FormVerbalContinueInstruction(
         element_max_count, delim, maneuver.verbal_formatter());
   }
 
+  instruction += " for ";
+  instruction += FormDistance(maneuver, units);
   instruction += ".";
   return instruction;
 }

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -68,6 +68,7 @@ class NarrativeBuilder {
 
   static std::string FormVerbalContinueInstruction(
       Maneuver& maneuver,
+      DirectionsOptions_Units units,
       uint32_t element_max_count = kVerbalPreElementMaxCount,
       std::string delim = kVerbalDelim);
 

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -336,15 +336,13 @@ class NarrativeBuilder {
       uint32_t element_max_count = kVerbalPostElementMaxCount,
       std::string delim = kVerbalDelim);
 
-  static std::string FormVerbalPostTransitionKilometersInstruction(
-      Maneuver& maneuver, bool include_street_names = false,
-      uint32_t element_max_count = kVerbalPostElementMaxCount,
-      std::string delim = kVerbalDelim);
+  /////////////////////////////////////////////////////////////////////////////
+  static std::string FormDistance(Maneuver& maneuver,
+                                  DirectionsOptions_Units units);
 
-  static std::string FormVerbalPostTransitionMilesInstruction(
-      Maneuver& maneuver, bool include_street_names = false,
-      uint32_t element_max_count = kVerbalPostElementMaxCount,
-      std::string delim = kVerbalDelim);
+  static std::string FormKilometers(float kilometers);
+
+  static std::string FormMiles(float miles);
 
   /////////////////////////////////////////////////////////////////////////////
   static std::string FormCardinalDirection(

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -36,6 +36,7 @@ class NarrativeBuilder {
 
   static std::string FormVerbalStartInstruction(
       Maneuver& maneuver,
+      DirectionsOptions_Units units,
       uint32_t element_max_count = kVerbalPreElementMaxCount,
       std::string delim = kVerbalDelim);
 


### PR DESCRIPTION
cc @ecgreb

START MANEUVER BEFORE
VERBAL_PRE: Go southwest on West Chocolate Avenue, U.S. 4 22.
VERBAL_POST: Continue for 6 tenths of a mile.

START MANEUVER AFTER
VERBAL_PRE: Go southwest on West Chocolate Avenue, U.S. 4 22 for 6 tenths of a mile.


CONTINUE MANEUVER BEFORE
VERBAL_PRE: Continue on U.S. 3 22 West.
VERBAL_POST: Continue for 6.8 miles.

CONTINUE MANEUVER AFTER
VERBAL_PRE: Continue on U.S. 3 22 West for 6.8 miles.
