### PR TITLE
Changed "Go" to "Head" for the following instructions: Start, ExitFerry, and PostTransitConnectionDestination

### DIFF
--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -411,9 +411,9 @@ void NarrativeBuilder::Build(const DirectionsOptions& directions_options,
 // dictionary
 
 std::string NarrativeBuilder::FormStartInstruction(Maneuver& maneuver) {
-  // 0 "Go <FormCardinalDirection>."
-  // 1 "Go <FormCardinalDirection> on <STREET_NAMES>."
-  // 2 "Go <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
+  // 0 "Head <FormCardinalDirection>."
+  // 1 "Head <FormCardinalDirection> on <STREET_NAMES>."
+  // 2 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
 
   std::string instruction;
   instruction.reserve(kTextInstructionInitialCapacity);
@@ -434,21 +434,21 @@ std::string NarrativeBuilder::FormStartInstruction(Maneuver& maneuver) {
   }
 
   switch (phrase_id) {
-    // 1 "Go <FormCardinalDirection> on <STREET_NAMES>."
+    // 1 "Head <FormCardinalDirection> on <STREET_NAMES>."
     case 1: {
-      instruction = (boost::format("Go %1% on %2%.")
+      instruction = (boost::format("Head %1% on %2%.")
           % cardinal_direction % street_names).str();
       break;
     }
-    // 2 "Go <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
+    // 2 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
     case 2: {
-      instruction = (boost::format("Go %1% on %2%. Continue on %3%.")
+      instruction = (boost::format("Head %1% on %2%. Continue on %3%.")
           % cardinal_direction % begin_street_names % street_names).str();
       break;
     }
-    // 0 "Go <FormCardinalDirection>."
+    // 0 "Head <FormCardinalDirection>."
     default: {
-      instruction = (boost::format("Go %1%.") % cardinal_direction).str();
+      instruction = (boost::format("Head %1%.") % cardinal_direction).str();
       break;
     }
   }
@@ -460,9 +460,9 @@ std::string NarrativeBuilder::FormStartInstruction(Maneuver& maneuver) {
 std::string NarrativeBuilder::FormVerbalStartInstruction(
     Maneuver& maneuver, DirectionsOptions_Units units,
     uint32_t element_max_count, std::string delim) {
-  // 0 "Go <FormCardinalDirection> for <DISTANCE>."
-  // 1 "Go <FormCardinalDirection> on <BEGIN_STREET_NAMES>."
-  // 2 "Go <FormCardinalDirection> on <STREET_NAMES> for <DISTANCE>."
+  // 0 "Head <FormCardinalDirection> for <DISTANCE>."
+  // 1 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>."
+  // 2 "Head <FormCardinalDirection> on <STREET_NAMES> for <DISTANCE>."
 
   std::string instruction;
   instruction.reserve(kTextInstructionInitialCapacity);
@@ -483,22 +483,22 @@ std::string NarrativeBuilder::FormVerbalStartInstruction(
   }
 
   switch (phrase_id) {
-    // 1 "Go <FormCardinalDirection> on <BEGIN_STREET_NAMES>."
+    // 1 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>."
     case 1: {
-      instruction = (boost::format("Go %1% on %2%.")
+      instruction = (boost::format("Head %1% on %2%.")
           % cardinal_direction % street_names).str();
       break;
     }
-    // 2 "Go <FormCardinalDirection> on <STREET_NAMES> for <DISTANCE>."
+    // 2 "Head <FormCardinalDirection> on <STREET_NAMES> for <DISTANCE>."
     case 2: {
-      instruction = (boost::format("Go %1% on %2% for %3%.")
+      instruction = (boost::format("Head %1% on %2% for %3%.")
           % cardinal_direction % street_names % FormDistance(maneuver, units))
           .str();
       break;
     }
-    // 0 "Go <FormCardinalDirection> for <DISTANCE>."
+    // 0 "Head <FormCardinalDirection> for <DISTANCE>."
     default: {
-      instruction = (boost::format("Go %1% for %2%.") % cardinal_direction
+      instruction = (boost::format("Head %1% for %2%.") % cardinal_direction
           % FormDistance(maneuver, units)).str();
       break;
     }
@@ -2628,13 +2628,13 @@ std::string NarrativeBuilder::FormVerbalEnterFerryInstruction(
 }
 
 std::string NarrativeBuilder::FormExitFerryInstruction(Maneuver& maneuver) {
-  //  0 "Go <FormCardinalDirection>."
-  //  1 "Go <FormCardinalDirection> on <STREET_NAMES>."
-  //  2 "Go <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
+  //  0 "Head <FormCardinalDirection>."
+  //  1 "Head <FormCardinalDirection> on <STREET_NAMES>."
+  //  2 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
 
   std::string instruction;
   instruction.reserve(kTextInstructionInitialCapacity);
-  instruction += "Go ";
+  instruction += "Head ";
   instruction += FormCardinalDirection(
       maneuver.begin_cardinal_direction());
 
@@ -2654,20 +2654,20 @@ std::string NarrativeBuilder::FormExitFerryInstruction(Maneuver& maneuver) {
 
 std::string NarrativeBuilder::FormVerbalAlertExitFerryInstruction(
     Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
-  //  0 "Go <FormCardinalDirection>."
-  //  1 "Go <FormCardinalDirection> on <BEGIN_STREET_NAMES|STREET_NAMES(1)>."
+  //  0 "Head <FormCardinalDirection>."
+  //  1 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES|STREET_NAMES(1)>."
 
   return FormVerbalExitFerryInstruction(maneuver, element_max_count, delim);
 }
 
 std::string NarrativeBuilder::FormVerbalExitFerryInstruction(
     Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
-  //  0 "Go <FormCardinalDirection>."
-  //  1 "Go <FormCardinalDirection> on <BEGIN_STREET_NAMES|STREET_NAMES(2)>."
+  //  0 "Head <FormCardinalDirection>."
+  //  1 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES|STREET_NAMES(2)>."
 
   std::string instruction;
   instruction.reserve(kTextInstructionInitialCapacity);
-  instruction += "Go ";
+  instruction += "Head ";
   instruction += FormCardinalDirection(maneuver.begin_cardinal_direction());
 
   if (maneuver.HasBeginStreetNames()) {
@@ -2824,7 +2824,7 @@ void NarrativeBuilder::FormPostTransitConnectionDestinationInstruction(
     Maneuver& maneuver) {
   std::string text_instruction;
   text_instruction.reserve(kTextInstructionInitialCapacity);
-  text_instruction += "Go ";
+  text_instruction += "Head ";
   text_instruction += FormCardinalDirection(
       maneuver.begin_cardinal_direction());
 

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -607,9 +607,9 @@ void TestBuildStartInstructions_0_miles_en_US() {
   PopulateStartManeuverList_0(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(
       expected_maneuvers,
-      "Go east.",
+      "Head east.",
       "",
-      "Go east for a half mile.",
+      "Head east for a half mile.",
       "");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
@@ -633,9 +633,9 @@ void TestBuildStartInstructions_1_miles_en_US() {
   PopulateStartManeuverList_1(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(
       expected_maneuvers,
-      "Go southwest on 5th Avenue.",
+      "Head southwest on 5th Avenue.",
       "",
-      "Go southwest on 5th Avenue for 1 tenth of a mile.",
+      "Head southwest on 5th Avenue for 1 tenth of a mile.",
       "");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
@@ -659,9 +659,9 @@ void TestBuildStartInstructions_2_miles_en_US() {
   PopulateStartManeuverList_2(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(
       expected_maneuvers,
-      "Go south on North Prince Street/US 222/PA 272. Continue on US 222/PA 272.",
+      "Head south on North Prince Street/US 222/PA 272. Continue on US 222/PA 272.",
       "",
-      "Go south on North Prince Street, U.S. 2 22.",
+      "Head south on North Prince Street, U.S. 2 22.",
       "Continue on U.S. 2 22, Pennsylvania 2 72 for 3.2 miles.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
@@ -685,9 +685,9 @@ void TestBuildStartInstructions_0_kilometers_en_US() {
   PopulateStartManeuverList_0(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(
       expected_maneuvers,
-      "Go east.",
+      "Head east.",
       "",
-      "Go east for 800 meters.",
+      "Head east for 800 meters.",
       "");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
@@ -711,9 +711,9 @@ void TestBuildStartInstructions_1_kilometers_en_US() {
   PopulateStartManeuverList_1(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(
       expected_maneuvers,
-      "Go southwest on 5th Avenue.",
+      "Head southwest on 5th Avenue.",
       "",
-      "Go southwest on 5th Avenue for 200 meters.",
+      "Head southwest on 5th Avenue for 200 meters.",
       "");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
@@ -737,9 +737,9 @@ void TestBuildStartInstructions_2_kilometers_en_US() {
   PopulateStartManeuverList_2(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(
       expected_maneuvers,
-      "Go south on North Prince Street/US 222/PA 272. Continue on US 222/PA 272.",
+      "Head south on North Prince Street/US 222/PA 272. Continue on US 222/PA 272.",
       "",
-      "Go south on North Prince Street, U.S. 2 22.",
+      "Head south on North Prince Street, U.S. 2 22.",
       "Continue on U.S. 2 22, Pennsylvania 2 72 for 5.1 kilometers.");
 
 
@@ -1416,9 +1416,9 @@ void TestBuildUturnInstructions_5_miles_en_US() {
   PopulateUturnManeuverList_5(expected_maneuvers, country_code, state_code);
   SetExpectedPreviousManeuverInstructions(
       expected_maneuvers,
-      "Go northeast on Jonestown Road/US 22.",
+      "Head northeast on Jonestown Road/US 22.",
       "",
-      "Go northeast on Jonestown Road, U.S. 22 for 200 feet.",
+      "Head northeast on Jonestown Road, U.S. 22 for 200 feet.",
       "");
   SetExpectedManeuverInstructions(
       expected_maneuvers,


### PR DESCRIPTION
BEFORE
Go south on Stone Road.
AFTER
Head south on Stone Road.
