### PR TITLE
Collapse the TransitConnectionStart and TransitConnectionDestination Maneuvers if the corresponding stop is not a station

### DIFF
--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -36,6 +36,16 @@ class ManeuversBuilder {
 
   void Combine(std::list<Maneuver>& maneuvers);
 
+  std::list<Maneuver>::iterator CollapseTransitConnectionStartManeuver(
+      std::list<Maneuver>& maneuvers,
+      std::list<Maneuver>::iterator curr_man,
+      std::list<Maneuver>::iterator next_man);
+
+  std::list<Maneuver>::iterator CollapseTransitConnectionDestinationManeuver(
+      std::list<Maneuver>& maneuvers,
+      std::list<Maneuver>::iterator curr_man,
+      std::list<Maneuver>::iterator next_man);
+
   std::list<Maneuver>::iterator CombineInternalManeuver(
       std::list<Maneuver>& maneuvers, std::list<Maneuver>::iterator prev_man,
       std::list<Maneuver>::iterator curr_man,


### PR DESCRIPTION
There we will not call out to enter or exit a simple stop such as a bus stop