### PR TITLE
Added ability to disable narrative production.

### DIFF
--- a/proto/directions_options.proto
+++ b/proto/directions_options.proto
@@ -9,4 +9,5 @@ message DirectionsOptions {
 
   optional Units units = 1;                         // kKilometers or kMiles
   optional string language = 2 [default = "en-US"]; // Based on IETF BCP 47 language tag string
+  optional bool narrative = 3 [default = true];     // Enable/disable narrative production
 }

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -95,6 +95,19 @@ const ::valhalla::odin::TripPath_Location& EnhancedTripPath::GetDestination() co
   return location(location_size() - 1);
 }
 
+float EnhancedTripPath::GetLength(const DirectionsOptions::Units& units) {
+  float length = 0.0f;
+  for (const auto& n : node()) {
+    if (n.has_edge()) {
+      length += n.edge().length();
+    }
+  }
+  if (units == DirectionsOptions::Units::DirectionsOptions_Units_kMiles) {
+    return (length * kMilePerKm);
+  }
+  return length;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // EnhancedTripPath_Edge
 

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -50,6 +50,11 @@ DirectionsOptions GetDirectionsOptions(const boost::property_tree::ptree& pt) {
     directions_options.set_language(*lang_ptr);
   }
 
+  auto narr_ptr = pt.get_optional<bool>("narrative");
+  if (narr_ptr) {
+    directions_options.set_narrative(*narr_ptr);
+  }
+
   return directions_options;
 }
 

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -42,6 +42,8 @@ class EnhancedTripPath : public TripPath {
 
   const ::valhalla::odin::TripPath_Location& GetDestination() const;
 
+  float GetLength(const DirectionsOptions::Units& units);
+
 };
 
 class EnhancedTripPath_Edge : public TripPath_Edge {


### PR DESCRIPTION
Closes #171 
Added "narrative" flag to directions_options to allow users to disable narrative production. Locations, shape, length, and time are still returned.
The narrative production is enabled by default.

Example:
http://localhost:8002/route?json={"locations":[{"lat":39.287403,"lon":-76.615128,"street":"South Charles Street"},{"lat":39.537704,"lon":-76.351112,"street":"North Main Street"}],"costing":"auto","directions_options":{"units":"miles","narrative":false}}

![screenshot from 2016-01-07 15 29 55](https://cloud.githubusercontent.com/assets/7515853/12182004/8eaecb02-b553-11e5-890f-47cb4e044710.png)
