### PR TITLE
Added verbal multi-cue capability

### DIFF
--- a/proto/tripdirections.proto
+++ b/proto/tripdirections.proto
@@ -154,6 +154,7 @@ message TripDirections {
     optional string arrive_instruction = 20;                 // arrive instruction - used with transit
     optional string verbal_arrive_instruction = 21;          // verbal arrive instruction - used with transit
     optional TransitRoute transit_route = 22;                // transit route attributes including a list of transit stops
+    optional bool verbal_multi_cue = 23;                     // verbal multi-cue flag
   }
   
   optional uint64 trip_id = 1;

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -308,6 +308,10 @@ TripDirections DirectionsBuilder::PopulateTripDirections(
       }
     }
 
+    // Verbal multi-cue
+    if (maneuver.verbal_multi_cue())
+      trip_maneuver->set_verbal_multi_cue(maneuver.verbal_multi_cue());
+
   }
 
   // Populate summary

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -39,6 +39,7 @@ Maneuver::Maneuver()
     : type_(TripDirections_Maneuver_Type_kNone),
       length_(0.0f),
       time_(0),
+      basic_time_(0),
       turn_degree_(0),
       begin_relative_direction_(RelativeDirection::kNone),
       begin_cardinal_direction_(
@@ -72,7 +73,8 @@ Maneuver::Maneuver()
       tee_(false),
       unnamed_walkway_(false),
       unnamed_cycleway_(false),
-      unnamed_mountain_bike_trail_(false) {
+      unnamed_mountain_bike_trail_(false),
+      verbal_multi_cue_(false) {
   street_names_ = make_unique<StreetNames>();
   begin_street_names_ = make_unique<StreetNames>();
   cross_street_names_ = make_unique<StreetNames>();
@@ -211,6 +213,14 @@ uint32_t Maneuver::time() const {
 
 void Maneuver::set_time(uint32_t time) {
   time_ = time;
+}
+
+uint32_t Maneuver::basic_time() const {
+  return basic_time_;
+}
+
+void Maneuver::set_basic_time(uint32_t basic_time) {
+  basic_time_ = basic_time;
 }
 
 uint32_t Maneuver::turn_degree() const {
@@ -536,6 +546,14 @@ void Maneuver::set_unnamed_mountain_bike_trail(bool unnamed_mountain_bike_trail)
   unnamed_mountain_bike_trail_ = unnamed_mountain_bike_trail;
 }
 
+bool Maneuver::verbal_multi_cue() const {
+  return verbal_multi_cue_;
+}
+
+void Maneuver::set_verbal_multi_cue(bool verbal_multi_cue) {
+  verbal_multi_cue_ = verbal_multi_cue;
+}
+
 TripPath_TravelMode Maneuver::travel_mode() const {
   return travel_mode_;
 }
@@ -812,6 +830,12 @@ std::string Maneuver::ToString() const {
   man_str += " | unnamed_mountain_bike_trail=";
   man_str += std::to_string(unnamed_mountain_bike_trail_);
 
+  man_str += " | basic_time=";
+  man_str += std::to_string(basic_time_);
+
+  man_str += " | verbal_multi_cue=";
+  man_str += std::to_string(verbal_multi_cue_);
+
   man_str += " | travel_mode=";
   man_str += std::to_string(travel_mode_);
 
@@ -969,6 +993,12 @@ std::string Maneuver::ToParameterString() const {
 
   man_str += delim;
   man_str += std::to_string(unnamed_mountain_bike_trail_);
+
+  man_str += delim;
+  man_str += std::to_string(basic_time_);
+
+  man_str += delim;
+  man_str += std::to_string(verbal_multi_cue_);
 
   // Transit TODO
 //  man_str += delim;

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -431,6 +431,9 @@ std::list<Maneuver>::iterator ManeuversBuilder::CombineInternalManeuver(
   // Add time
   next_man->set_time(next_man->time() + curr_man->time());
 
+  // Add basic time
+  next_man->set_basic_time(next_man->basic_time() + curr_man->basic_time());
+
   // TODO - heading?
 
   // Set begin node index
@@ -474,6 +477,9 @@ std::list<Maneuver>::iterator ManeuversBuilder::CombineTurnChannelManeuver(
   // Add time
   next_man->set_time(next_man->time() + curr_man->time());
 
+  // Add basic time
+  next_man->set_basic_time(next_man->basic_time() + curr_man->basic_time());
+
   // TODO - heading?
 
   // Set begin node index
@@ -502,6 +508,9 @@ std::list<Maneuver>::iterator ManeuversBuilder::CombineSameNameStraightManeuver(
 
   // Add time
   curr_man->set_time(curr_man->time() + next_man->time());
+
+  // Add basic time
+  curr_man->set_basic_time(curr_man->basic_time() + next_man->basic_time());
 
   // Update end heading
   curr_man->set_end_heading(next_man->end_node_index());
@@ -788,6 +797,11 @@ void ManeuversBuilder::UpdateManeuver(Maneuver& maneuver, int node_index) {
 
   // Distance in kilometers
   maneuver.set_length(maneuver.length() + prev_edge->length());
+
+  // Basic time (len/speed on each edge with no stop impact) in seconds
+  maneuver.set_basic_time(maneuver.basic_time()
+          + GetTime(prev_edge->length(),
+                    GetSpeed(maneuver.travel_mode(), prev_edge->speed())));
 
   // Portions Toll
   if (prev_edge->toll()) {
@@ -1792,6 +1806,17 @@ void ManeuversBuilder::UpdateInternalTurnCount(Maneuver& maneuver,
     maneuver.set_internal_left_turn_count(
         maneuver.internal_left_turn_count() + 1);
   }
+}
+
+float ManeuversBuilder::GetSpeed(TripPath_TravelMode travel_mode,
+                                float edge_speed) const {
+  // TODO use pedestrian and bicycle speeds from costing options?
+  if (travel_mode == TripPath_TravelMode_kPedestrian)
+    return 5.1f;
+  else if (travel_mode == TripPath_TravelMode_kBicycle)
+    return 20.0f;
+  else
+    return edge_speed;
 }
 
 }

--- a/test/maneuversbuilder.cc
+++ b/test/maneuversbuilder.cc
@@ -505,7 +505,10 @@ void PopulateManeuver(
     std::string verbal_transition_alert_instruction = "",
     std::string verbal_pre_transition_instruction = "",
     std::string verbal_post_transition_instruction = "",
-    bool tee = false) {
+    bool tee = false,
+    bool unnamed_walkway = false, bool unnamed_cycleway = false,
+    bool unnamed_mountain_bike_trail = false, float basic_time = 0.0f,
+    bool verbal_multi_cue = false) {
 
   maneuver.set_type(type);
 
@@ -586,6 +589,11 @@ void PopulateManeuver(
   maneuver.set_verbal_pre_transition_instruction(verbal_pre_transition_instruction);
   maneuver.set_verbal_post_transition_instruction(verbal_post_transition_instruction);
   maneuver.set_tee(tee);
+  maneuver.set_unnamed_walkway(unnamed_walkway);
+  maneuver.set_unnamed_cycleway(unnamed_cycleway);
+  maneuver.set_unnamed_mountain_bike_trail(unnamed_mountain_bike_trail);
+  maneuver.set_basic_time(basic_time);
+  maneuver.set_verbal_multi_cue(verbal_multi_cue);
 }
 
 void TestLeftInternalStraightCombine() {

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -66,7 +66,10 @@ void PopulateManeuver(
     bool intersecting_forward_edge = false,
     std::string verbal_transition_alert_instruction = "",
     std::string verbal_pre_transition_instruction = "",
-    std::string verbal_post_transition_instruction = "", bool tee = false) {
+    std::string verbal_post_transition_instruction = "", bool tee = false,
+    bool unnamed_walkway = false, bool unnamed_cycleway = false,
+    bool unnamed_mountain_bike_trail = false, float basic_time = 0.0f,
+    bool verbal_multi_cue = false) {
 
   maneuver.set_verbal_formatter(
       VerbalTextFormatterFactory::Create(country_code, state_code));
@@ -150,6 +153,11 @@ void PopulateManeuver(
   maneuver.set_verbal_pre_transition_instruction(verbal_pre_transition_instruction);
   maneuver.set_verbal_post_transition_instruction(verbal_post_transition_instruction);
   maneuver.set_tee(tee);
+  maneuver.set_unnamed_walkway(unnamed_walkway);
+  maneuver.set_unnamed_cycleway(unnamed_cycleway);
+  maneuver.set_unnamed_mountain_bike_trail(unnamed_mountain_bike_trail);
+  maneuver.set_basic_time(basic_time);
+  maneuver.set_verbal_multi_cue(verbal_multi_cue);
 }
 
 void TryBuild(const DirectionsOptions& directions_options,
@@ -446,7 +454,7 @@ void PopulateBearManeuverList_3(std::list<Maneuver>& maneuvers,
                    Maneuver::RelativeDirection::kRight,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 201, 204,
                    161, 187, 1461, 1805, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { },
-                   { }, { }, 1, 0, 0, 0, 1, 0, "", "", "", 0);
+                   { }, { }, 1, 0, 0, 0, 1, 0, "", "", "", 0, 0, 0, 0, 900, 0);
   maneuvers.emplace_back();
   Maneuver& maneuver2 = maneuvers.back();
   PopulateManeuver(maneuver2, country_code, state_code,
@@ -455,7 +463,7 @@ void PopulateBearManeuverList_3(std::list<Maneuver>& maneuvers,
                    Maneuver::RelativeDirection::kKeepLeft,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 193, 197,
                    187, 197, 1805, 1878, 0, 0, 0, 0, 0, 0, 0, 1, 0, { }, { },
-                   { }, { }, 0, 0, 0, 0, 0, 1, "", "", "", 0);
+                   { }, { }, 0, 0, 0, 0, 0, 1, "", "", "", 0, 0, 0, 0, 200, 0);
 }
 
 void PopulateUturnManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -497,7 +505,7 @@ void PopulateUturnManeuverList_2(std::list<Maneuver>& maneuvers,
                    Maneuver::RelativeDirection::kRight,
                    TripDirections_Maneuver_CardinalDirection_kNorthWest, 335,
                    337, 2, 3, 36, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
-                   { }, 1, 0, 0, 0, 1, 1, "", "", "", 0);
+                   { }, 1, 0, 0, 0, 1, 1, "", "", "", 0, 0, 0, 0, 20, 0);
   maneuvers.emplace_back();
   Maneuver& maneuver2 = maneuvers.back();
   PopulateManeuver(maneuver2, country_code, state_code,
@@ -506,7 +514,7 @@ void PopulateUturnManeuverList_2(std::list<Maneuver>& maneuvers,
                    Maneuver::RelativeDirection::KReverse,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 157, 155,
                    3, 4, 46, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { },
-                   0, 0, 0, 0, 0, 0, "", "", "", 0);
+                   0, 0, 0, 0, 0, 0, "", "", "", 0, 0, 0, 0, 20, 0);
 }
 
 void PopulateUturnManeuverList_3(std::list<Maneuver>& maneuvers,
@@ -546,11 +554,11 @@ void PopulateUturnManeuverList_5(std::list<Maneuver>& maneuvers,
   PopulateManeuver(maneuver1, country_code, state_code,
                    TripDirections_Maneuver_Type_kStart, { "Jonestown Road",
                        "US 22" },
-                   { }, { }, "", 0.062923, 0, 0,
+                   { }, { }, "", 0.062923, 2, 0,
                    Maneuver::RelativeDirection::kNone,
                    TripDirections_Maneuver_CardinalDirection_kNorthEast, 36, 32,
                    0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { }, 0,
-                   0, 0, 0, 1, 0, "", "", "", 0);
+                   0, 0, 0, 1, 0, "", "", "", 0, 0, 0, 0, 2, 0);
   maneuvers.emplace_back();
   Maneuver& maneuver2 = maneuvers.back();
   PopulateManeuver(maneuver2, country_code, state_code,
@@ -560,7 +568,7 @@ void PopulateUturnManeuverList_5(std::list<Maneuver>& maneuvers,
                    Maneuver::RelativeDirection::KReverse,
                    TripDirections_Maneuver_CardinalDirection_kSouthWest, 212,
                    221, 1, 3, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
-                   { }, 0, 1, 0, 0, 1, 0, "", "", "", 0);
+                   { }, 0, 1, 0, 0, 1, 0, "", "", "", 0, 0, 0, 0, 40, 0);
 }
 
 void SetExpectedManeuverInstructions(
@@ -1090,7 +1098,7 @@ void TestBuildTurnInstructions_3_miles_en_US() {
       expected_maneuvers,
       "Turn right onto Sunstone Drive.",
       "Turn right onto Sunstone Drive.",
-      "Turn right onto Sunstone Drive.",
+      "Turn right onto Sunstone Drive. Then Turn right to stay on Sunstone Drive.",
       "Continue for 300 feet.");
   SetExpectedManeuverInstructions(
       expected_maneuvers,
@@ -1418,7 +1426,7 @@ void TestBuildUturnInstructions_5_miles_en_US() {
       expected_maneuvers,
       "Head northeast on Jonestown Road/US 22.",
       "",
-      "Head northeast on Jonestown Road, U.S. 22 for 200 feet.",
+      "Head northeast on Jonestown Road, U.S. 22 for 200 feet. Then Make a left U-turn at Devonshire Road.",
       "");
   SetExpectedManeuverInstructions(
       expected_maneuvers,

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -73,8 +73,13 @@ class Maneuver {
       DirectionsOptions::Units::DirectionsOptions_Units_kKilometers) const;
   void set_length(float length);
 
+  // Seconds
   uint32_t time() const;
   void set_time(uint32_t time);
+
+  // len/speed on each edge with no stop impact in seconds
+  uint32_t basic_time() const;
+  void set_basic_time(uint32_t basic_time);
 
   uint32_t turn_degree() const;
   void set_turn_degree(uint32_t turn_degree);
@@ -193,6 +198,9 @@ class Maneuver {
   bool unnamed_mountain_bike_trail() const;
   void set_unnamed_mountain_bike_trail(bool unnamed_mountain_bike_trail);
 
+  bool verbal_multi_cue() const;
+  void set_verbal_multi_cue(bool verbal_multi_cue);
+
   TripPath_TravelMode travel_mode() const;
   void set_travel_mode(TripPath_TravelMode travel_mode);
 
@@ -263,7 +271,8 @@ class Maneuver {
   std::unique_ptr<StreetNames> cross_street_names_;
   std::string instruction_;
   float length_;     // Kilometers
-  uint32_t time_;
+  uint32_t time_;    // Seconds
+  uint32_t basic_time_; // len/speed on each edge with no stop impact in seconds
   uint32_t turn_degree_;
   RelativeDirection begin_relative_direction_;
   TripDirections_Maneuver_CardinalDirection begin_cardinal_direction_;
@@ -296,6 +305,7 @@ class Maneuver {
   bool unnamed_walkway_;
   bool unnamed_cycleway_;
   bool unnamed_mountain_bike_trail_;
+  bool verbal_multi_cue_;
 
   ////////////////////////////////////////////////////////////////////////////
   // Transit support

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -110,6 +110,16 @@ class ManeuversBuilder {
 
   void UpdateInternalTurnCount(Maneuver& maneuver, int node_index) const;
 
+  /**
+   * Returns the speed based on the specified travel mode.
+   *
+   * @param travel_mode The current specified travel mode.
+   * @param edge_speed The speed of the current edge - used for driving mode.
+   *
+   * @return the speed based on the specified travel mode.
+   */
+  float GetSpeed(TripPath_TravelMode travel_mode, float edge_speed) const;
+
   const DirectionsOptions& directions_options_;
   EnhancedTripPath* trip_path_;
 

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -381,6 +381,41 @@ class NarrativeBuilder {
       std::string delim = "/",
       const VerbalTextFormatter* verbal_formatter = nullptr);
 
+  /////////////////////////////////////////////////////////////////////////////
+  /**
+   * Processes the specified maneuver list and creates verbal multi-cue
+   * instructions based on quick maneuvers.
+   *
+   * @param maneuvers The maneuver list to process.
+   */
+  static void FormVerbalMultiCue(std::list<Maneuver>& maneuvers);
+
+  /**
+   * Returns the verbal multi-cue instruction based on the specified maneuvers.
+   *
+   * @param maneuver The current quick maneuver that will be the first verbal
+   *                 cue in the returned instruction.
+   * @param next_maneuver The next maneuver that will be the second verbal cue
+   *                      in the returned instruction.
+   *
+   * @return the verbal multi-cue instruction based on the specified maneuvers.
+   */
+  static std::string FormVerbalMultiCue(Maneuver* maneuver,
+                                        Maneuver& next_maneuver);
+
+  /**
+   * Returns true if a verbal multi-cue instruction should be formed for the
+   * two specified maneuvers.
+   *
+   * @param maneuver The current maneuver that must be short based on time.
+   * @param next_maneuver The next maneuver that must meet criteria to be used.
+   *
+   * @return true if a verbal multi-cue instruction should be formed for the
+   *         two specified maneuvers.
+   */
+  static bool IsVerbalMultiCuePossible(Maneuver* maneuver,
+                                       Maneuver& next_maneuver);
+
 };
 
 }


### PR DESCRIPTION
Fixes #176 

Appends the verbal pre-transition instruction of a short (by time) maneuver with the verbal transition alert instruction of the next maneuver

BEFORE
![screenshot from 2016-02-19 12 30 56](https://cloud.githubusercontent.com/assets/7515853/13183593/a577340e-d705-11e5-8f65-61c56db06c69.png)


AFTER
![screenshot from 2016-02-19 12 32 12](https://cloud.githubusercontent.com/assets/7515853/13183604/afe00f38-d705-11e5-80e8-2be12518031e.png)
