### PR TITLE
add german scratch translation. break out sharp into its own turn phr…

### DIFF
--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -835,12 +835,12 @@
     },
     "post_transit_connection_destination": {
       "phrases": {
-        "0": "Head <CARDINAL_DIRECTION>.",
-        "1": "Head <CARDINAL_DIRECTION> on <STREET_NAMES>.",
-        "2": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
+        "0": "Nach <CARDINAL_DIRECTION>.",
+        "1": "Auf <STREET_NAMES> nach <CARDINAL_DIRECTION>.",
+        "2": "Auf <BEGIN_STREET_NAMES> nach <CARDINAL_DIRECTION>. Dann weiter auf <STREET_NAMES>."
       },
-      "cardinal_directions": ["north", "northeast", "east", "southeast", "south", "southwest", "west", "northwest"],
-      "empty_street_name_labels": ["walkway", "cycleway", "mountain bike trail"],
+      "cardinal_directions": ["Norden", "Nordosten", "Osten", "Südosten", "Süden", "Südwesten", "Westen", "Nordwesten"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
       "example_phrases": {
         "0": ["Head west."],
         "1": ["Head northeast on Broadway"],
@@ -849,12 +849,12 @@
     },
     "post_transit_connection_destination_verbal": {
       "phrases": {
-        "0": "Head <CARDINAL_DIRECTION>.",
-        "1": "Head <CARDINAL_DIRECTION> on <STREET_NAMES>.",
-        "2": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>."
+        "0": "Nach <CARDINAL_DIRECTION>.",
+        "1": "Auf <STREET_NAMES> nach <CARDINAL_DIRECTION>.",
+        "2": "Auf <BEGIN_STREET_NAMES> nach <CARDINAL_DIRECTION>."
       },
-      "cardinal_directions": ["north", "northeast", "east", "southeast", "south", "southwest", "west", "northwest"],
-      "empty_street_name_labels": ["walkway", "cycleway", "mountain bike trail"],
+      "cardinal_directions": ["Norden", "Nordosten", "Osten", "Südosten", "Süden", "Südwesten", "Westen", "Nordwesten"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
       "example_phrases": {
         "0": ["Head west."],
         "1": ["Head northeast on Broadway"],
@@ -872,9 +872,9 @@
     },
     "post_transition_transit_verbal": {
       "phrases": {
-        "0": "Travel <TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>."
+        "0": "<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL> fahren."
       },
-      "transit_stop_count_labels": ["stop", "stops"],
+      "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
       "example_phrases": {
         "0": ["Travel 1 stop.", "Travel 3 stops."]
       }

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -706,8 +706,8 @@
         "1": "Am Bahnhof <TRANSIT_STOP> umsteigen."
       },
       "example_phrases": {
-        "0": ["Enter the station."],
-        "1": ["Enter the 8 St - NYU Station."]
+        "0": ["Transfer at the station."],
+        "1": ["Transfer at the Embarcadero Station."]
       }
     },
     "transit_connection_destination": {

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -770,13 +770,69 @@
         "1": ["Arrive at 8:02 AM at 8 St - NYU."]
       }
     },
-    "transit": null,
-    "transit_verbal": null,
-    "post_transition_transit_verbal": null,
-    "transit_remain_on": null,
-    "transit_remain_on_verbal": null,
-    "transit_transfer": null,
-    "transit_transfer_verbal": null,
+    "transit": {
+      "phrases": {
+        "0": "Mit der Linie <TRANSIT_NAME> fahren. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
+        "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> fahren. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
+      },
+      "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
+      "example_phrases": {
+        "0": ["Take the New Haven. (1 stop)"],
+        "1": ["Take the F toward JAMAICA - 179 ST. (10 stops)"]
+      }
+    },
+    "transit_verbal": {
+      "phrases": {
+        "0": "Mit der Linie <TRANSIT_NAME> fahren.",
+        "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> fahren."
+      },
+      "example_phrases": {
+        "0": ["Take the New Haven."],
+        "1": ["Take the F toward JAMAICA - 179 ST."]
+      }
+    },
+    "transit_remain_on": {
+      "phrases": {
+        "0": "Mit der Linie <TRANSIT_NAME> weiter. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
+        "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> weiter. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
+      },
+      "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
+      "example_phrases": {
+        "0": ["Remain on the New Haven. (1 stop)"],
+        "1": ["Remain on the F toward JAMAICA - 179 ST. (10 stops)"]
+      }
+    },
+    "transit_remain_on_verbal": {
+      "phrases": {
+        "0": "Mit der Linie <TRANSIT_NAME> weiter.",
+        "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> weiter."
+      },
+      "example_phrases": {
+        "0": ["Remain on the New Haven."],
+        "1": ["Remain on the F toward JAMAICA - 179 ST."]
+      }
+    },
+    "transit_transfer": {
+      "phrases": {
+        "0": "Zur Linie <TRANSIT_NAME> umsteigen. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
+        "1": "Zur Linie <TRANSIT_NAME> Richtugn <TRANSIT_HEADSIGN> umsteigen. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
+      },
+      "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
+      "example_phrases": {
+        "0": ["Transfer to take the New Haven. (1 stop)"],
+        "1": ["Transfer to take the F toward JAMAICA - 179 ST. (10 stops)"]
+      }
+    },
+    "transit_transfer_verbal": {
+      "phrases": {
+        "0": "Zur Linie <TRANSIT_NAME> umsteigen.",
+        "1": "Zur Linie <TRANSIT_NAME> Richtugn <TRANSIT_HEADSIGN> umsteigen."
+      },
+      "example_phrases": {
+        "0": ["Transfer to take the New Haven."],
+        "1": ["Transfer to take the F toward JAMAICA - 179 ST."]
+      }
+    },
     "post_transit_connection_destination": null,
     "post_transit_connection_destination_verbal": null,
     "post_transition_verbal": {

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -670,12 +670,66 @@
         "2": ["Head south on Summerfield Place, New York 1 14."]
       }
     },
-    "transit_connection_start": null,
-    "transit_connection_start_verbal": null,
-    "transit_connection_transfer": null,
-    "transit_connection_transfer_verbal": null,
-    "transit_connection_destination": null,
-    "transit_connection_destination_verbal": null,
+    "transit_connection_start": {
+      "phrases": {
+        "0": "Bahnhof eintreten.",
+        "1": "Bahnhof <TRANSIT_STOP> eintreten."
+      },
+      "example_phrases": {
+        "0": ["Enter the station."],
+        "1": ["Enter the 8 St - NYU Station."]
+      }
+    },
+    "transit_connection_start_verbal": {
+      "phrases": {
+        "0": "Bahnhof eintreten.",
+        "1": "Bahnhof <TRANSIT_STOP> eintreten."
+      },
+      "example_phrases": {
+        "0": ["Enter the station."],
+        "1": ["Enter the 8 St - NYU Station."]
+      }
+    },
+    "transit_connection_transfer": {
+      "phrases": {
+        "0": "Am Bahnhof umsteigen.",
+        "1": "Am Bahnhof <TRANSIT_STOP> umsteigen."
+      },
+      "example_phrases": {
+        "0": ["Transfer at the station."],
+        "1": ["Transfer at the Embarcadero Station."]
+      }
+    },
+    "transit_connection_transfer_verbal": {
+      "phrases": {
+        "0": "Am Bahnhof umsteigen.",
+        "1": "Am Bahnhof <TRANSIT_STOP> umsteigen."
+      },
+      "example_phrases": {
+        "0": ["Enter the station."],
+        "1": ["Enter the 8 St - NYU Station."]
+      }
+    },
+    "transit_connection_destination": {
+      "phrases": {
+        "0": "Bahnhof verlassen.",
+        "1": "Bahnhof <TRANSIT_STOP> verlassen."
+      },
+      "example_phrases": {
+        "0": ["Exit the station."],
+        "1": ["Exit the 8 St - NYU Station."]
+      }
+    },
+    "transit_connection_destination_verbal": {
+      "phrases": {
+        "0": "Bahnhof verlassen.",
+        "1": "Bahnhof <TRANSIT_STOP> verlassen."
+      },
+      "example_phrases": {
+        "0": ["Exit the station."],
+        "1": ["Exit the 8 St - NYU Station."]
+      }
+    },
     "depart": null,
     "depart_verbal": null,
     "arrive": null,

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -1,0 +1,709 @@
+{
+  "instructions": {
+    "start": {
+      "phrases": {
+        "0": "Nach <CARDINAL_DIRECTION>.",
+        "1": "Auf <STREET_NAMES> nach <CARDINAL_DIRECTION>.",
+        "2": "Auf <BEGIN_STREET_NAMES> nach <CARDINAL_DIRECTION>. Dann weiter auf <STREET_NAMES>."
+      },
+      "cardinal_directions": ["Norden", "Nordosten", "Osten", "Südosten", "Süden", "Südwesten", "Westen", "Nordwesten"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Nach Osten.", "Nach Norden."],
+        "1": ["Auf Hauptstraße nach Südwesten."],
+        "2": ["Auf A 1 nach Süden. Dann weiter auf B 13."]
+      }
+    },
+    "start_verbal": {
+      "phrases": {
+        "0": "<LENGTH> nach <CARDINAL_DIRECTION>.",
+        "1": "<LENGTH> auf <STREET_NAMES> nach <CARDINAL_DIRECTION>.",
+        "2": "<LENGTH> auf <BEGIN_STREET_NAMES> nach <CARDINAL_DIRECTION>."
+      },
+      "cardinal_directions": ["Norden", "Nordosten", "Osten", "Südosten", "Süden", "Südwesten", "Westen", "Nordwesten"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "metric_lengths": ["<KILOMETERS> Kilometer", "einen Kilometer", "einen halben Kilometer", "<METERS> Meter", "weniger als 10 Meter"],
+      "us_customary_lengths": ["<MILES> Milen", "eine Meile", "eine halbe Meile", "<TENTHS_OF_MILE> zehntel der Meile", "eine zehntel der Miele", "<FEET> Füße", "weniger als 10 Füße"],
+      "example_phrases": {
+        "0": ["Head east for a half mile.", "Head north for 1 kilometer."],
+        "1": ["Head southwest on 5th Avenue for 1 tenth of a mile."],
+        "2": ["Head south on North Prince Street, U.S. 2 22."]
+      }
+    },
+    "destination": {
+      "phrases": {
+        "0": "Ziel erreichen.",
+        "1": "<DESTINATION> erreichen.",
+        "2": "Ziel befindet sich auf der <RELATIVE_DIRECTION> Seite.",
+        "3": "<DESTINATION> befindet sich auf der <RELATIVE_DIRECTION> Seite."
+      },
+      "relative_directions": ["linken", "rechten"],
+      "example_phrases": {
+        "0": ["You have arrived at your destination."],
+        "1": ["You have arrived at 3206 Powelton Avenue."],
+        "2": ["Your destination is on the left.", "Your destination is on the right."],
+        "3": ["Lancaster Brewing Company is on the left."]
+      }
+    },
+    "destination_verbal_alert": {
+      "phrases": {
+        "0": "Ziel gleich erreichen.",
+        "1": "<DESTINATION> gleich erreichen.",
+        "2": "Gleich befindet sich das Ziel auf der <RELATIVE_DIRECTION> Seite.",
+        "3": "Gleich befindet sich <DESTINATION> auf der <RELATIVE_DIRECTION> Seite."
+      },
+      "relative_directions": ["linken", "rechten"],
+      "example_phrases": {
+        "0": ["You will arrive at your destination."],
+        "1": ["You will arrive at 32 o6 Powelton Avenue."],
+        "2": ["Your destination will be on the left.", "Your destination will be on the right."],
+        "3": ["Lancaster Brewing Company will be on the left."]
+      }
+    },
+    "destination_verbal": {
+      "phrases": {
+        "0": "Ziel erreichen.",
+        "1": "<DESTINATION> erreichen.",
+        "2": "Ziel befindet sich auf der <RELATIVE_DIRECTION> Seite.",
+        "3": "<DESTINATION> befindet sich auf der <RELATIVE_DIRECTION> Seite."
+      },
+      "relative_directions": ["linken", "rechten"],
+      "example_phrases": {
+        "0": ["You have arrived at your destination."],
+        "1": ["You have arrived at 32 o6 Powelton Avenue."],
+        "2": ["Your destination is on the left.", "Your destination is on the right."],
+        "3": ["Lancaster Brewing Company is on the left."]
+      }
+    },
+    "becomes": {
+      "phrases": {
+        "0": "<PREV_STREET_NAMES> wird <STREET_NAMES>."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Vine Street becomes Middletown Road."]
+      }
+    },
+    "becomes_verbal": {
+      "phrases": {
+        "0": "<PREV_STREET_NAMES> wird <STREET_NAMES>."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Vine Street becomes Middletown Road."]
+      }
+    },
+    "continue": {
+      "phrases": {
+        "0": "Weiter.",
+        "1": "Weiter auf <STREET_NAMES>."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Continue."],
+        "1": ["Continue on 10th Avenue."]
+      }
+    },
+    "continue_verbal_alert": {
+      "phrases": {
+        "0": "Weiter.",
+        "1": "Weiter auf <STREET_NAMES>."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Continue."],
+        "1": ["Continue on 10th Avenue."]
+      }
+    },
+    "continue_verbal": {
+      "phrases": {
+        "0": "<LENGTH> weiter.",
+        "1": "<LENGTH> weiter auf <STREET_NAMES>."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "metric_lengths": ["<KILOMETERS> kilometers", "1 kilometer", "a half kilometer", "<METERS> meters", "less than 10 meters"],
+      "us_customary_lengths": ["<MILES> miles", "1 mile", "a half mile", "<TENTHS_OF_MILE> tenths of a mile", "1 tenth of a mile", "<FEET> feet", "less than 10 feet"],
+      "example_phrases": {
+        "0": ["Continue for 300 feet."],
+        "1": ["Continue on 10th Avenue for 3 tenths of a mile."]
+      }
+    },
+    "bear": {
+      "phrases": {
+        "0": "Leicht nach <RELATIVE_DIRECTION> abbiegen.",
+        "1": "Leicht nach <RELATIVE_DIRECTION> auf <STREET_NAMES> abbiegen.",
+        "2": "Leight nach <RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
+        "3": "Leicht nach <RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben."
+      },
+      "relative_directions": ["links", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Bear right."],
+        "1": ["Bear left onto Arlen Road."],
+        "2": ["Bear right onto Belair Road/US 1 Business. Continue on US 1 Business."],
+        "3": ["Bear left to stay on US 15 South."]
+      }
+    },
+    "bear_verbal": {
+      "phrases": {
+        "0": "Leicht nach <RELATIVE_DIRECTION> abbiegen.",
+        "1": "Leicht nach <RELATIVE_DIRECTION> auf <STREET_NAMES> abbiegen.",
+        "2": "Leight nach <RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
+        "3": "Leicht nach <RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben."
+      },
+      "relative_directions": ["links", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Bear right."],
+        "1": ["Bear left onto Arlen Road."],
+        "2": ["Bear right onto Belair Road, U.S. 1 Business."],
+        "3": ["Bear left to stay on U.S. 15 South."]
+      }
+    },
+    "turn": {
+      "phrases": {
+        "0": "<RELATIVE_DIRECTION> abbiegen.",
+        "1": "<RELATIVE_DIRECTION> auf <STREET_NAMES> abbiegen.",
+        "2": "<RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
+        "3": "<RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben."
+      },
+      "relative_directions": ["links", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Turn left."],
+        "1": ["Turn right onto Flatbush Avenue."],
+        "2": ["Turn left onto North Bond Street/US 1 Business/MD 924. Continue on MD 924."],
+        "3": ["Turn right to stay on Sunstone Drive."]
+      }
+    },
+    "turn_verbal": {
+      "phrases": {
+        "0": "<RELATIVE_DIRECTION> abbiegen.",
+        "1": "<RELATIVE_DIRECTION> auf <STREET_NAMES> abbiegen.",
+        "2": "<RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
+        "3": "<RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben."
+      },
+      "relative_directions": ["links", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Turn left."],
+        "1": ["Turn right onto Flatbush Avenue."],
+        "2": ["Turn left onto North Bond Street, U.S. 1 Business."],
+        "3": ["Turn right to stay on Sunstone Drive."]
+      }
+    },
+    "sharp": {
+      "phrases": {
+        "0": "Scharf nach <RELATIVE_DIRECTION> abbiegen.",
+        "1": "Scharf nach <RELATIVE_DIRECTION> auf <STREET_NAMES> abbiegen.",
+        "2": "Scharf nach <RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
+        "3": "Scharf nach <RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben."
+      },
+      "relative_directions": ["links", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Turn sharp right."],
+        "1": ["Turn sharp left onto Arlen Road."],
+        "2": ["Turn sharp right onto Belair Road/US 1 Business. Continue on US 1 Business."],
+        "3": ["Turn sharp left to stay on US 15 South."]
+      }
+    },
+    "sharp_verbal": {
+      "phrases": {
+        "0": "Scharf nach <RELATIVE_DIRECTION> abbiegen.",
+        "1": "Scharf nach <RELATIVE_DIRECTION> auf <STREET_NAMES> abbiegen.",
+        "2": "Scharf nach <RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
+        "3": "Scharf nach <RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben."
+      },
+      "relative_directions": ["links", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Turn sharp right."],
+        "1": ["Turn sharp left onto Arlen Road."],
+        "2": ["Turn sharp right onto Belair Road, U.S. 1 Business."],
+        "3": ["Turn sharp left to stay on U.S. 15 South."]
+      }
+    },
+    "uturn": {
+      "phrases": {
+        "0": "Nach <RELATIVE_DIRECTION> eine Kehrtwende machen.",
+        "1": "Nach <RELATIVE_DIRECTION> eine Kehrtwende auf <STREET_NAMES> machen.",
+        "2": "Nach <RELATIVE_DIRECTION> eine Kehrtwende machen um auf <STREET_NAMES> zu bleiben.",
+        "3": "Nach <RELATIVE_DIRECTION> eine Kerhtwende bei <CROSS_STREET_NAMES> machen.",
+        "4": "Nach <RELATIVE_DIRECTION> eine Kerhtwende bei <CROSS_STREET_NAMES> auf <STREET_NAMES> machen.",
+        "5": "Nach <RELATIVE_DIRECTION> eine Kerhtwende bei <CROSS_STREET_NAMES> machen um auf <STREET_NAMES> zu bleiben."
+      },
+      "relative_directions": ["links", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Make a left U-turn."],
+        "1": ["Make a right U-turn onto Bunker Hill Road."],
+        "2": ["Make a left U-turn to stay on Bunker Hill Road."],
+        "3": ["Make a left U-turn at Devonshire Road."],
+        "4": ["Make a left U-turn at Devonshire Road onto Jonestown Road/US 22."],
+        "5": ["Make a left U-turn at Devonshire Road to stay on Jonestown Road/US 22."]
+      }
+    },
+    "uturn_verbal_alert": {
+      "phrases": {
+        "0": "Nach <RELATIVE_DIRECTION> eine Kehrtwende machen.",
+        "1": "Nach <RELATIVE_DIRECTION> eine Kehrtwende auf <STREET_NAMES> machen.",
+        "2": "Nach <RELATIVE_DIRECTION> eine Kehrtwende machen um auf <STREET_NAMES> zu bleiben.",
+        "3": "Nach <RELATIVE_DIRECTION> eine Kerhtwende bei <CROSS_STREET_NAMES> machen."
+      },
+      "relative_directions": ["links", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Make a left U-turn."],
+        "1": ["Make a right U-turn onto Bunker Hill Road."],
+        "2": ["Make a left U-turn to stay on Bunker Hill Road."],
+        "3": ["Make a left U-turn at Devonshire Road."]
+      }
+    },
+    "uturn_verbal": {
+      "phrases": {
+        "0": "Nach <RELATIVE_DIRECTION> eine Kehrtwende machen.",
+        "1": "Nach <RELATIVE_DIRECTION> eine Kehrtwende auf <STREET_NAMES> machen.",
+        "2": "Nach <RELATIVE_DIRECTION> eine Kehrtwende machen um auf <STREET_NAMES> zu bleiben.",
+        "3": "Nach <RELATIVE_DIRECTION> eine Kerhtwende bei <CROSS_STREET_NAMES> machen.",
+        "4": "Nach <RELATIVE_DIRECTION> eine Kerhtwende bei <CROSS_STREET_NAMES> auf <STREET_NAMES> machen.",
+        "5": "Nach <RELATIVE_DIRECTION> eine Kerhtwende bei <CROSS_STREET_NAMES> machen um auf <STREET_NAMES> zu bleiben."
+      },
+      "relative_directions": ["links", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Make a left U-turn."],
+        "1": ["Make a right U-turn onto Bunker Hill Road."],
+        "2": ["Make a left U-turn to stay on Bunker Hill Road."],
+        "3": ["Make a left U-turn at Devonshire Road."],
+        "4": ["Make a left U-turn at Devonshire Road onto Jonestown Road, U.S. 22."],
+        "5": ["Make a left U-turn at Devonshire Road to stay on Jonestown Road, U.S. 22."]
+      }
+    },
+    "ramp_straight": {
+      "phrases": {
+        "0": "Geradeaus über die Rampe fahren.",
+        "1": "Auf <BRANCH_SIGN> geradeaus über die Rampe fahren.",
+        "2": "Geradeaus über die Rampe fahren Richtung <TOWARD_SIGN>.",
+        "3": "Auf <BRANCH_SIGN> geradeaus über die Rampe fahren Richtung <TOWARD_SIGN>.",
+        "4": "Geradeaus über die Rampe <NAME_SIGN> fahren."
+      },
+      "example_phrases": {
+        "0": ["Stay straight to take the ramp."],
+        "1": ["Stay straight to take the US 322 East ramp."],
+        "2": ["Stay straight to take the ramp toward Hershey."],
+        "3": ["Stay straight to take the US 322 East/US 422 East/US 522 East/US 622 East ramp toward Hershey/Palmdale/Palmyra/Campbelltown."],
+        "4": ["Stay straight to take the Gettysburg Pike ramp."]
+      }
+    },
+    "ramp_straight_verbal_alert": {
+      "phrases": {
+        "0": "Geradeaus über die Rampe fahren.",
+        "1": "Auf <BRANCH_SIGN> geradeaus über die Rampe fahren.",
+        "2": "Geradeaus über die Rampe fahren Richtung <TOWARD_SIGN>.",
+        "4": "Geradeaus über die Rampe <NAME_SIGN> fahren."
+      },
+      "example_phrases": {
+        "0": ["Stay straight to take the ramp."],
+        "1": ["Stay straight to take the U.S. 3 22 East ramp."],
+        "2": ["Stay straight to take the ramp toward Hershey."],
+        "3": ["Stay straight to take the Gettysburg Pike ramp."]
+      }
+    },
+    "ramp_straight_verbal": {
+      "phrases": {
+        "0": "Geradeaus über die Rampe fahren.",
+        "1": "Auf <BRANCH_SIGN> geradeaus über die Rampe fahren.",
+        "2": "Geradeaus über die Rampe fahren Richtung <TOWARD_SIGN>.",
+        "3": "Auf <BRANCH_SIGN> geradeaus über die Rampe fahren Richtung <TOWARD_SIGN>.",
+        "4": "Geradeaus über die Rampe <NAME_SIGN> fahren."
+      },
+      "example_phrases": {
+        "0": ["Stay straight to take the ramp."],
+        "1": ["Stay straight to take the U.S. 3 22 East ramp."],
+        "2": ["Stay straight to take the ramp toward Hershey."],
+        "3": ["Stay straight to take the U.S. 3 22 East, U.S. 4 22 East ramp toward Hershey, Palmdale."],
+        "4": ["Stay straight to take the Gettysburg Pike ramp."]
+      }
+    },
+    "ramp": {
+      "phrases": {
+        "0": "Auf die Rampe leicht nach <RELATIVE_DIRECTION> abbiegen.",
+        "1": "Über die Rampe leicht nach <RELATIVE_DIRECTION> auf <BRANCH_SIGN> abbiegen.",
+        "2": "Auf die Rampe leicht nach <RELATIVE_DIRECTION> abbiegen Richtung <TOWARD_SIGN>.",
+        "3": "Über die Rampe leicht nach <RELATIVE_DIRECTION> auf <BRANCH_SIGN> abbiegen Richtung <TOWARD_SIGN>.",
+        "4": "Auf die Rampe <NAME_SIGN> leicht nach <RELATIVE_DIRECTION> abbiegen.",
+        "5": "Auf die Rampe nach <RELATIVE_DIRECTION> abbiegen.",
+        "6": "Über die Rampe nach <RELATIVE_DIRECTION> auf <BRANCH_SIGN> abbiegen.",
+        "7": "Auf die Rampe nach <RELATIVE_DIRECTION> abbiegen Richtung <TOWARD_SIGN>.",
+        "8": "Über die Rampe nach <RELATIVE_DIRECTION> auf <BRANCH_SIGN> abbiegen Richtung <TOWARD_SIGN>.",
+        "9": "Auf die Rampe <NAME_SIGN> nach <RELATIVE_DIRECTION> abbiegen."
+      },
+      "relative_directions": ["links", "rechts"],
+      "example_phrases": {
+        "0": ["Take the ramp on the left.", "Take the ramp on the right."],
+        "1": ["Take the I 95 ramp on the right."],
+        "2": ["Take the ramp on the left toward JFK."],
+        "3": ["Take the South Conduit Avenue ramp on the left toward JFK."],
+        "4": ["Take the Gettysburg Pike ramp on the right."],
+        "5": ["Turn left to take the ramp.", "Turn right to take the ramp."],
+        "6": ["Turn left to take the PA 283 West ramp."],
+        "7": ["Turn left to take the ramp toward Harrisburg/Harrisburg International Airport."],
+        "8": ["Turn left to take the PA 283 West ramp toward Harrisburg/Harrisburg International Airport."],
+        "9": ["Turn right to take the Gettysburg Pike ramp."]
+      }
+    },
+    "ramp_verbal": {
+      "phrases": {
+        "0": "Auf die Rampe leicht nach <RELATIVE_DIRECTION> abbiegen.",
+        "1": "Über die Rampe leicht nach <RELATIVE_DIRECTION> auf <BRANCH_SIGN> abbiegen.",
+        "2": "Auf die Rampe leicht nach <RELATIVE_DIRECTION> abbiegen Richtung <TOWARD_SIGN>.",
+        "3": "Über die Rampe leicht nach <RELATIVE_DIRECTION> auf <BRANCH_SIGN> abbiegen Richtung <TOWARD_SIGN>.",
+        "4": "Auf die Rampe <NAME_SIGN> leicht nach <RELATIVE_DIRECTION> abbiegen.",
+        "5": "Auf die Rampe nach <RELATIVE_DIRECTION> abbiegen.",
+        "6": "Über die Rampe nach <RELATIVE_DIRECTION> auf <BRANCH_SIGN> abbiegen.",
+        "7": "Auf die Rampe nach <RELATIVE_DIRECTION> abbiegen Richtung <TOWARD_SIGN>.",
+        "8": "Über die Rampe nach <RELATIVE_DIRECTION> auf <BRANCH_SIGN> abbiegen Richtung <TOWARD_SIGN>.",
+        "9": "Auf die Rampe <NAME_SIGN> nach <RELATIVE_DIRECTION> abbiegen."
+      },
+      "relative_directions": ["links", "rechts"],
+      "example_phrases": {
+        "0": ["Take the ramp on the left.", "Take the ramp on the right."],
+        "1": ["Take the Interstate 95 ramp on the right."],
+        "2": ["Take the ramp on the left toward JFK."],
+        "3": ["Take the South Conduit Avenue ramp on the left toward JFK."],
+        "4": ["Take the Gettysburg Pike ramp on the right."],
+        "5": ["Turn left to take the ramp.", "Turn right to take the ramp."],
+        "6": ["Turn left to take the Pennsylvania 2 83 West ramp."],
+        "7": ["Turn left to take the ramp toward Harrisburg/Harrisburg International Airport."],
+        "8": ["Turn left to take the Pennsylvania 2 83 West ramp toward Harrisburg, Harrisburg International Airport."],
+        "9": ["Turn right to take the Gettysburg Pike ramp."]
+      }
+    },
+    "exit": {
+      "phrases": {
+        "0": "An der Ausfahrt <RELATIVE_DIRECTION> abfahren.",
+        "1": "An der Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "2": "Auf <BRANCH_SIGN> über die Ausfahrt <RELATIVE_DIRECTION> abfahren.",
+        "3": "Auf <BRANCH_SIGN> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "4": "An der Ausfahrt <RELATIVE_DIRECTION> abfahren Richtung <TOWARD_SIGN>.",
+        "5": "An der Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> abfahren Richtung <TOWARD_SIGN>.",
+        "6": "Auf <BRANCH_SIGN> Richtung <TOWARD_SIGN> über die Ausfahrt <RELATIVE_DIRECTION> abfahren.",
+        "7": "Auf <BRANCH_SIGN> Richtung <TOWARD_SIGN> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "8": "An der Ausfahrt <NAME_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "10": "Auf <BRANCH_SIGN> über die Ausfahrt <NAME_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "12": "An der Ausfahrt <NAME_SIGN> <RELATIVE_DIRECTION> abfahren Richtung <TOWARD_SIGN>.",
+        "14": "Auf <BRANCH_SIGN> Richtung <TOWARD_SIGN> über die Ausfahrt <NAME_SIGN> <RELATIVE_DIRECTION> abfahren."
+      },
+      "relative_directions": ["links", "rechts"],
+      "example_phrases": {
+        "0": ["Take the exit on the left.", "Take the exit on the right."],
+        "1": ["Take exit 67 B-A on the right."],
+        "2": ["Take the US 322 West exit on the right."],
+        "3": ["Take exit 67 B-A on the right onto US 322 West."],
+        "4": ["Take the exit on the right toward Lewistown."],
+        "5": ["Take exit 67 B-A on the right toward Lewistown."],
+        "6": ["Take the US 322 West exit on the right toward Lewistown."],
+        "7": ["Take exit 67 B-A on the right onto US 322 West toward Lewistown/State College."],
+        "8": ["Take the White Marsh Boulevard exit on the left."],
+        "10": ["Take the White Marsh Boulevard exit on the left onto MD 43 East."],
+        "12": ["Take the White Marsh Boulevard exit on the left toward White Marsh."],
+        "14": ["Take the White Marsh Boulevard exit on the left onto MD 43 East toward White Marsh."]
+      }
+    },
+    "exit_verbal": {
+      "phrases": {
+        "0": "An der Ausfahrt <RELATIVE_DIRECTION> abfahren.",
+        "1": "An der Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "2": "Auf <BRANCH_SIGN> über die Ausfahrt <RELATIVE_DIRECTION> abfahren.",
+        "3": "Auf <BRANCH_SIGN> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "4": "An der Ausfahrt <RELATIVE_DIRECTION> abfahren Richtung <TOWARD_SIGN>.",
+        "5": "An der Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> abfahren Richtung <TOWARD_SIGN>.",
+        "6": "Auf <BRANCH_SIGN> Richtung <TOWARD_SIGN> über die Ausfahrt <RELATIVE_DIRECTION> abfahren.",
+        "7": "Auf <BRANCH_SIGN> Richtung <TOWARD_SIGN> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "8": "An der Ausfahrt <NAME_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "10": "Auf <BRANCH_SIGN> über die Ausfahrt <NAME_SIGN> <RELATIVE_DIRECTION> abfahren.",
+        "12": "An der Ausfahrt <NAME_SIGN> <RELATIVE_DIRECTION> abfahren Richtung <TOWARD_SIGN>.",
+        "14": "Auf <BRANCH_SIGN> Richtung <TOWARD_SIGN> über die Ausfahrt <NAME_SIGN> <RELATIVE_DIRECTION> abfahren."
+      },
+      "relative_directions": ["links", "rechts"],
+      "example_phrases": {
+        "0": ["Take the exit on the left.", "Take the exit on the right."],
+        "1": ["Take exit 67 B-A on the right."],
+        "2": ["Take the U.S. 3 22 West exit on the right."],
+        "3": ["Take exit 67 B-A on the right onto U.S. 3 22 West."],
+        "4": ["Take the exit on the right toward Lewistown."],
+        "5": ["Take exit 67 B-A on the right toward Lewistown."],
+        "6": ["Take the U.S. 3 22 West exit on the right toward Lewistown."],
+        "7": ["Take exit 67 B-A on the right onto U.S. 3 22 West toward Lewistown, State College."],
+        "8": ["Take the White Marsh Boulevard exit on the left."],
+        "10": ["Take the White Marsh Boulevard exit on the left onto Maryland 43 East."],
+        "12": ["Take the White Marsh Boulevard exit on the left toward White Marsh."],
+        "14": ["Take the White Marsh Boulevard exit on the left onto Maryland 43 East toward White Marsh."]
+      }
+    },
+    "keep": {
+      "phrases": {
+        "0": "An der Gabelung <RELATIVE_DIRECTION> halten.",
+        "1": "<RELATIVE_DIRECTION> halten auf die Ausfahrt <NUMBER_SIGN>.",
+        "2": "<RELATIVE_DIRECTION> halten auf <STREET_NAMES>.",
+        "3": "<RELATIVE_DIRECTION> halten um die Ausfahrt <NUMBER_SIGN> auf <STREET_NAMES> zu nehmen.",
+        "4": "<RELATIVE_DIRECTION> halten Richtung <TOWARD_SIGN>.",
+        "5": "<RELATIVE_DIRECTION> halten um die Ausfahrt <NUMBER_SIGN> Richtung <TOWARD_SIGN> zu nehmen.",
+        "6": "<RELATIVE_DIRECTION> halten auf <STREET_NAMES> Richtung <TOWARD_SIGN>.",
+        "7": "<RELATIVE_DIRECTION> halften um die Ausfahrt <NUMBER_SIGN> auf <STREET_NAMES> Richtung <TOWARD_SIGN> zu nehmen."
+      },
+      "relative_directions": ["links", "geradeaus", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Keep left at the fork.", "Keep straight at the fork.", "Keep right at the fork."],
+        "1": ["Keep right to take exit 62."],
+        "2": ["Keep right to take I 895 South."],
+        "3": ["Keep right to take exit 62 onto I 895 South."],
+        "4": ["Keep right toward Annapolis."],
+        "5": ["Keep right to take exit 62 toward Annapolis."],
+        "6": ["Keep right to take I 895 South toward Annapolis."],
+        "7": ["Keep right to take exit 62 onto I 895 South toward Annapolis."]
+      }
+    },
+    "keep_verbal": {
+      "phrases": {
+        "0": "An der Gabelung <RELATIVE_DIRECTION> halten.",
+        "1": "<RELATIVE_DIRECTION> halten auf die Ausfahrt <NUMBER_SIGN>.",
+        "2": "<RELATIVE_DIRECTION> halten auf <STREET_NAMES>.",
+        "3": "<RELATIVE_DIRECTION> halten um die Ausfahrt <NUMBER_SIGN> auf <STREET_NAMES> zu nehmen.",
+        "4": "<RELATIVE_DIRECTION> halten Richtung <TOWARD_SIGN>.",
+        "5": "<RELATIVE_DIRECTION> halten um die Ausfahrt <NUMBER_SIGN> Richtung <TOWARD_SIGN> zu nehmen.",
+        "6": "<RELATIVE_DIRECTION> halten auf <STREET_NAMES> Richtung <TOWARD_SIGN>.",
+        "7": "<RELATIVE_DIRECTION> halften um die Ausfahrt <NUMBER_SIGN> auf <STREET_NAMES> Richtung <TOWARD_SIGN> zu nehmen."
+      },
+      "relative_directions": ["links", "geradeaus", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Keep left at the fork.", "Keep straight at the fork.", "Keep right at the fork."],
+        "1": ["Keep right to take exit 62."],
+        "2": ["Keep right to take Interstate 8 95 South."],
+        "3": ["Keep right to take exit 62 onto Interstate 8 95 South."],
+        "4": ["Keep right toward Annapolis."],
+        "5": ["Keep right to take exit 62 toward Annapolis."],
+        "6": ["Keep right to take Interstate 8 95 South toward Annapolis."],
+        "7": ["Keep right to take exit 62 onto Interstate 8 95 South toward Annapolis."]
+      }
+    },
+    "keep_to_stay_on": {
+      "phrases": {
+        "0": "Auf <STREET_NAMES> <RELATIVE_DIRECTION> halten.",
+        "1": "Auf <STREET_NAMES> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> halten.",
+        "2": "Auf <STREET_NAMES> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> halten.",
+        "3": "Auf <STREET_NAMES> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> halten Richtung <TOWARD_SIGN>."
+      },
+      "relative_directions": ["links", "geradeaus", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Keep left to stay on I 95 South.", "Keep straight to stay on I 95 South.", "Keep right to stay on I 95 South."],
+        "1": ["Keep left to take exit 62 to stay on I 95 South."],
+        "2": ["Keep left to stay on I 95 South toward Baltimore."],
+        "3": ["Keep left to take exit 62 to stay on I 95 South toward Baltimore."]
+      }
+    },
+    "keep_to_stay_on_verbal": {
+      "phrases": {
+        "0": "Auf <STREET_NAMES> <RELATIVE_DIRECTION> halten.",
+        "1": "Auf <STREET_NAMES> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> halten.",
+        "2": "Auf <STREET_NAMES> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> halten.",
+        "3": "Auf <STREET_NAMES> über die Ausfahrt <NUMBER_SIGN> <RELATIVE_DIRECTION> halten Richtung <TOWARD_SIGN>."
+      },
+      "relative_directions": ["links", "geradeaus", "rechts"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Keep left to stay on Interstate 95 South.", "Keep straight to stay on Interstate 95 South.", "Keep right to stay on Interstate 95 South."],
+        "1": ["Keep left to take exit 62 to stay on Interstate 95 South."],
+        "2": ["Keep left to stay on I 95 South toward Baltimore."],
+        "3": ["Keep left to take exit 62 to stay on Interstate 95 South toward Baltimore."]
+      }
+    },
+    "merge": {
+      "phrases": {
+        "0": "Einfädeln.",
+        "1": "Auf <STREET_NAMES> einfädeln."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Merge."],
+        "1": ["Merge onto I 76 West/Pennsylvania Turnpike."]
+      }
+    },
+    "merge_verbal": {
+      "phrases": {
+        "0": "Einfädeln.",
+        "1": "Auf <STREET_NAMES> einfädeln."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Merge."],
+        "1": ["Merge onto Interstate 76 West, Pennsylvania Turnpike."]
+      }
+    },
+    "enter_roundabout": {
+      "phrases": {
+        "0": "Kreisverkehr nehmen.",
+        "1": "Im Kreisverkehr die <ORDINAL_VALUE> Ausfahrt nehmen."
+      },
+      "ordinal_values": ["1.", "2.", "3.", "4.", "5.", "6.", "7.", "8.", "9.", "10."],
+      "example_phrases": {
+        "0": ["Enter the roundabout."],
+        "1": [
+          "Enter the roundabout and take the 1st exit.",
+          "Enter the roundabout and take the 2nd exit.",
+          "Enter the roundabout and take the 3rd exit.",
+          "Enter the roundabout and take the 4th exit.",
+          "Enter the roundabout and take the 5th exit.",
+          "Enter the roundabout and take the 6th exit.",
+          "Enter the roundabout and take the 7th exit.",
+          "Enter the roundabout and take the 8th exit.",
+          "Enter the roundabout and take the 9th exit.",
+          "Enter the roundabout and take the 10th exit."
+        ]
+      }
+    },
+    "enter_roundabout_verbal": {
+      "phrases": {
+        "0": "Kreisverkehr nehmen.",
+        "1": "Im Kreisverkehr die <ORDINAL_VALUE> Ausfahrt nehmen."
+      },
+      "ordinal_values": ["erste", "zweite", "dritte", "vierte", "fünfte", "sechste", "siebte", "ochte", "neunte", "zehnte"],
+      "example_phrases": {
+        "0": ["Enter the roundabout."],
+        "1": [
+          "Enter the roundabout and take the 1st exit.",
+          "Enter the roundabout and take the 2nd exit.",
+          "Enter the roundabout and take the 3rd exit.",
+          "Enter the roundabout and take the 4th exit.",
+          "Enter the roundabout and take the 5th exit.",
+          "Enter the roundabout and take the 6th exit.",
+          "Enter the roundabout and take the 7th exit.",
+          "Enter the roundabout and take the 8th exit.",
+          "Enter the roundabout and take the 9th exit.",
+          "Enter the roundabout and take the 10th exit."
+        ]
+      }
+    },
+    "exit_roundabout": {
+      "phrases": {
+        "0": "Dem Kreisverkehr abfahren.",
+        "1": "Dem Kreisverkehr auf <STREET_NAMES> abfahren.",
+        "2": "Dem Kreisverkehr auf <BEGIN_STREET_NAMES> abfahren. Dann weiter auf <STREET_NAMES>."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Exit the roundabout."],
+        "1": ["Exit the roundabout onto Philadelphia Road/MD 7."],
+        "2": ["Exit the roundabout onto Catoctin Mountain Highway/US 15. Continue on US 15."]
+      }
+    },
+    "exit_roundabout_verbal": {
+      "phrases": {
+        "0": "Dem Kreisverkehr abfahren.",
+        "1": "Dem Kreisverkehr auf <STREET_NAMES> abfahren.",
+        "2": "Dem Kreisverkehr auf <BEGIN_STREET_NAMES> abfahren. Dann weiter auf <STREET_NAMES>."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Exit the roundabout."],
+        "1": ["Exit the roundabout onto Philadelphia Road, Maryland 7."],
+        "2": ["Exit the roundabout onto Catoctin Mountain Highway, U.S. 15."]
+      }
+    },
+    "enter_ferry": {
+      "phrases": {
+        "0": "Die Fähre nehmen.",
+        "1": "Die <STREET_NAMES> nehmen.",
+        "2": "Die <STREET_NAMES> <FERRY_LABEL> nehmen."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "ferry_label": "Fähre",
+      "example_phrases": {
+        "0": ["Take the Ferry."],
+        "1": ["Take the Millersburg Ferry."],
+        "2": ["Take the Bridgeport - Port Jefferson Ferry."]
+      }
+    },
+    "enter_ferry_verbal": {
+      "phrases": {
+        "0": "Die Fähre nehmen.",
+        "1": "Die <STREET_NAMES> nehmen.",
+        "2": "Die <STREET_NAMES> <FERRY_LABEL> nehmen."
+      },
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "ferry_label": "Ferry",
+      "example_phrases": {
+        "0": ["Take the Ferry."],
+        "1": ["Take the Millersburg Ferry."],
+        "2": ["Take the Bridgeport - Port Jefferson Ferry."]
+      }
+    },
+    "exit_ferry": {
+      "phrases": {
+        "0": "Nach <CARDINAL_DIRECTION>.",
+        "1": "Auf <STREET_NAMES> nach <CARDINAL_DIRECTION>.",
+        "2": "Auf <BEGIN_STREET_NAMES> nach <CARDINAL_DIRECTION>. Dann weiter auf <STREET_NAMES>."
+      },
+      "cardinal_directions": ["Norden", "Nordosten", "Osten", "Südosten", "Süden", "Südwesten", "Westen", "Nordwesten"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
+      "example_phrases": {
+        "0": ["Head northeast."],
+        "1": ["Head west on Ferry Lane"],
+        "2": ["Head south on Summerfield Place/NY 114. Continue on NY 114."]
+      }
+    },
+    "exit_ferry_verbal": {
+      "phrases": {
+        "0": "Nach <CARDINAL_DIRECTION>.",
+        "1": "Auf <STREET_NAMES> nach <CARDINAL_DIRECTION>.",
+        "2": "Auf <BEGIN_STREET_NAMES> nach <CARDINAL_DIRECTION>."
+      },
+      "cardinal_directions": ["Norden", "Nordosten", "Osten", "Südosten", "Süden", "Südwesten", "Westen", "Nordwesten"],
+      "empty_street_name_labels": ["walkway", "cycleway", "mountain bike trail"],
+      "example_phrases": {
+        "0": ["Head northeast."],
+        "1": ["Head west on Ferry Lane"],
+        "2": ["Head south on Summerfield Place, New York 1 14."]
+      }
+    },
+    "transit_connection_start": null,
+    "transit_connection_start_verbal": null,
+    "transit_connection_transfer": null,
+    "transit_connection_transfer_verbal": null,
+    "transit_connection_destination": null,
+    "transit_connection_destination_verbal": null,
+    "depart": null,
+    "depart_verbal": null,
+    "arrive": null,
+    "arrive_verbal": null,
+    "transit": null,
+    "transit_verbal": null,
+    "post_transition_transit_verbal": null,
+    "transit_remain_on": null,
+    "transit_remain_on_verbal": null,
+    "transit_transfer": null,
+    "transit_transfer_verbal": null,
+    "post_transit_connection_destination": null,
+    "post_transit_connection_destination_verbal": null,
+    "post_transition_verbal": {
+      "phrases": {
+        "0": "<LENGTH> weiter.",
+        "1": "<LENGTH> weiter auf <STREET_NAMES>."
+      },
+      "metric_lengths": ["<KILOMETERS> Kilometer", "einen Kilometer", "einen halben Kilometer", "<METERS> Meter", "weniger als 10 Meter"],
+      "us_customary_lengths": ["<MILES> Milen", "eine Meile", "eine halbe Meile", "<TENTHS_OF_MILE> zehntel der Meile", "eine zehntel der Miele", "<FEET> Füße", "weniger als 10 Füße"],
+      "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"]
+    },
+    "verbal_multi_cue": {
+      "phrases": {
+        "0": "<CURRENT_VERBAL_CUE> Dann <NEXT_VERBAL_CUE>"
+      }
+    }
+    
+  }
+}
+

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -730,10 +730,46 @@
         "1": ["Exit the 8 St - NYU Station."]
       }
     },
-    "depart": null,
-    "depart_verbal": null,
-    "arrive": null,
-    "arrive_verbal": null,
+    "depart": {
+      "phrases": {
+        "0": "Abfahrt: <TIME>.",
+        "1": "Abfahrt: <TIME> an <TRANSIT_STOP>."
+      },
+      "example_phrases": {
+        "0": ["Depart: 8:02 AM."],
+        "1": ["Depart: 8:02 AM from 8 St - NYU."]
+      }
+    },
+    "depart_verbal": {
+      "phrases": {
+        "0": "Um <TIME> abfahren.",
+        "1": "Um <TIME> von <TRANSIT_STOP> abfahren."
+      },
+      "example_phrases": {
+        "0": ["Depart at 8:02 AM."],
+        "1": ["Depart at 8:02 AM from 8 St - NYU."]
+      }
+    },
+    "arrive": {
+      "phrases": {
+        "0": "Ankunft: <TIME>.",
+        "1": "Ankunft: <TIME> am <TRANSIT_STOP>."
+      },
+      "example_phrases": {
+        "0": ["Arrive: 8:02 AM."],
+        "1": ["Arrive: 8:02 AM at 8 St - NYU."]
+      }
+    },
+    "arrive_verbal": {
+      "phrases": {
+        "0": "Um <TIME> ankommen",
+        "1": "Um <TIME> am <TRANSIT_STOP> ankommen."
+      },
+      "example_phrases": {
+        "0": ["Arrive at 8:02 AM."],
+        "1": ["Arrive at 8:02 AM at 8 St - NYU."]
+      }
+    },
     "transit": null,
     "transit_verbal": null,
     "post_transition_transit_verbal": null,

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -167,12 +167,12 @@
         "2": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
         "3": "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
       },
-      "relative_directions": ["left", "sharp left", "right", "sharp right"],
+      "relative_directions": ["left", "right"],
       "empty_street_name_labels": ["walkway", "cycleway", "mountain bike trail"],
       "example_phrases": {
         "0": ["Turn left."],
-        "1": ["Turn sharp right onto Flatbush Avenue."],
-        "2": ["Turn sharp left onto North Bond Street/US 1 Business/MD 924. Continue on MD 924."],
+        "1": ["Turn right onto Flatbush Avenue."],
+        "2": ["Turn left onto North Bond Street/US 1 Business/MD 924. Continue on MD 924."],
         "3": ["Turn right to stay on Sunstone Drive."]
       }
     },
@@ -183,13 +183,45 @@
         "2": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
         "3": "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
       },
-      "relative_directions": ["left", "sharp left", "right", "sharp right"],
+      "relative_directions": ["left", "right"],
       "empty_street_name_labels": ["walkway", "cycleway", "mountain bike trail"],
       "example_phrases": {
         "0": ["Turn left."],
+        "1": ["Turn right onto Flatbush Avenue."],
+        "2": ["Turn left onto North Bond Street, U.S. 1 Business."],
+        "3": ["Turn right to stay on Sunstone Drive."]
+      }
+    },
+    "sharp": {
+      "phrases": {
+        "0": "Turn sharp <RELATIVE_DIRECTION>.",
+        "1": "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
+        "2": "Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
+        "3": "Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+      },
+      "relative_directions": ["left", "right"],
+      "empty_street_name_labels": ["walkway", "cycleway", "mountain bike trail"],
+      "example_phrases": {
+        "0": ["Turn sharp left."],
+        "1": ["Turn sharp right onto Flatbush Avenue."],
+        "2": ["Turn sharp left onto North Bond Street/US 1 Business/MD 924. Continue on MD 924."],
+        "3": ["Turn sharp right to stay on Sunstone Drive."]
+      }
+    },
+    "sharp_verbal": {
+      "phrases": {
+        "0": "Turn sharp <RELATIVE_DIRECTION>.",
+        "1": "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
+        "2": "Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
+        "3": "Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+      },
+      "relative_directions": ["left", "right"],
+      "empty_street_name_labels": ["walkway", "cycleway", "mountain bike trail"],
+      "example_phrases": {
+        "0": ["Turn sharp left."],
         "1": ["Turn sharp right onto Flatbush Avenue."],
         "2": ["Turn sharp left onto North Bond Street, U.S. 1 Business."],
-        "3": ["Turn right to stay on Sunstone Drive."]
+        "3": ["Turn sharp right to stay on Sunstone Drive."]
       }
     },
     "uturn": {

--- a/src/odin/narrative_dictionary.cc
+++ b/src/odin/narrative_dictionary.cc
@@ -84,6 +84,15 @@ void NarrativeDictionary::Load(
   Load(turn_verbal_subset, narrative_pt.get_child(kTurnVerbalKey));
 
   /////////////////////////////////////////////////////////////////////////////
+  LOG_TRACE("Populate sharp_subset...");
+  // Populate sharp_subset
+  Load(sharp_subset, narrative_pt.get_child(kSharpKey));
+
+  LOG_TRACE("Populate sharp_verbal_subset...");
+  // Populate sharp_verbal_subset
+  Load(sharp_verbal_subset, narrative_pt.get_child(kSharpVerbalKey));
+
+  /////////////////////////////////////////////////////////////////////////////
   LOG_TRACE("Populate uturn_subset...");
   // Populate uturn_subset
   Load(uturn_subset, narrative_pt.get_child(kUturnKey));

--- a/src/odin/narrative_dictionary.cc
+++ b/src/odin/narrative_dictionary.cc
@@ -209,6 +209,15 @@ void NarrativeDictionary::Load(
   Load(transit_connection_start_verbal_subset, narrative_pt.get_child(kTransitConnectionStartVerbalKey));
 
   /////////////////////////////////////////////////////////////////////////////
+  LOG_TRACE("Populate transit_connection_transfer_subset...");
+  // Populate transit_connection_transfer_subset
+  Load(transit_connection_transfer_subset, narrative_pt.get_child(kTransitConnectionTransferKey));
+
+  LOG_TRACE("Populate transit_connection_transfer_verbal_subset...");
+  // Populate transit_connection_transfer_verbal_subset
+  Load(transit_connection_transfer_verbal_subset, narrative_pt.get_child(kTransitConnectionTransferVerbalKey));
+
+  /////////////////////////////////////////////////////////////////////////////
   LOG_TRACE("Populate post_transition_verbal_subset...");
   // Populate post_transition_verbal_subset
   Load(post_transition_verbal_subset, narrative_pt.get_child(kPostTransitionVerbalKey));

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -105,26 +105,7 @@ void NarrativeBuilder::Build(const DirectionsOptions& directions_options,
         break;
       }
       case TripDirections_Maneuver_Type_kSlightRight:
-      case TripDirections_Maneuver_Type_kSlightLeft: {
-        // Set instruction
-        maneuver.set_instruction(
-            std::move(FormBearInstruction(maneuver, prev_maneuver)));
-
-        // Set verbal transition alert instruction
-        maneuver.set_verbal_transition_alert_instruction(
-            std::move(FormVerbalAlertBearInstruction(maneuver, prev_maneuver)));
-
-        // Set verbal pre transition instruction
-        maneuver.set_verbal_pre_transition_instruction(
-            std::move(FormVerbalBearInstruction(maneuver, prev_maneuver)));
-
-        // Set verbal post transition instruction
-        maneuver.set_verbal_post_transition_instruction(
-            std::move(
-                FormVerbalPostTransitionInstruction(
-                    maneuver, maneuver.HasBeginStreetNames())));
-        break;
-      }
+      case TripDirections_Maneuver_Type_kSlightLeft:
       case TripDirections_Maneuver_Type_kRight:
       case TripDirections_Maneuver_Type_kSharpRight:
       case TripDirections_Maneuver_Type_kSharpLeft:
@@ -591,7 +572,7 @@ std::string NarrativeBuilder::FormStartInstruction(Maneuver& maneuver) {
 }
 
 std::string NarrativeBuilder::FormVerbalStartInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Head <CARDINAL_DIRECTION> for <LENGTH>.",
   // "1": "Head <CARDINAL_DIRECTION> on <STREET_NAMES> for <LENGTH>.",
   // "2": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>.",
@@ -830,7 +811,7 @@ std::string NarrativeBuilder::FormBecomesInstruction(Maneuver& maneuver,
 
 std::string NarrativeBuilder::FormVerbalBecomesInstruction(
     Maneuver& maneuver, Maneuver* prev_maneuver, uint32_t element_max_count,
-    std::string delim) {
+    const std::string& delim) {
   // "<PREV_STREET_NAMES(2)> becomes <STREET_NAMES(2)>."
 
   // Assign the street names and the previous maneuver street names
@@ -897,7 +878,7 @@ std::string NarrativeBuilder::FormContinueInstruction(Maneuver& maneuver) {
 }
 
 std::string NarrativeBuilder::FormVerbalAlertContinueInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Continue.",
   // "1": "Continue on <STREET_NAMES>."
 
@@ -928,7 +909,7 @@ std::string NarrativeBuilder::FormVerbalAlertContinueInstruction(
 
 std::string NarrativeBuilder::FormVerbalContinueInstruction(
     Maneuver& maneuver, DirectionsOptions_Units units,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
   // "0": "Continue for <LENGTH>.",
   // "1": "Continue on <STREET_NAMES> for <LENGTH>."
 
@@ -962,10 +943,27 @@ std::string NarrativeBuilder::FormVerbalContinueInstruction(
 
 std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver,
                                                   Maneuver* prev_maneuver) {
-  // "0": "Turn <RELATIVE_DIRECTION>.",
-  // "1": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
-  // "2": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
-  // "3": "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+  // "0": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION>.",
+  // "1": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
+  // "2": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
+  // "3": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+  const TurnSubset* subset = nullptr;
+  switch (maneuver.type()) {
+      case TripDirections_Maneuver_Type_kSlightRight:
+      case TripDirections_Maneuver_Type_kSlightLeft:
+        subset = &dictionary_.bear_subset;
+        break;
+      case TripDirections_Maneuver_Type_kRight:
+      case TripDirections_Maneuver_Type_kLeft:
+        subset = &dictionary_.turn_subset;
+        break;
+      case TripDirections_Maneuver_Type_kSharpRight:
+      case TripDirections_Maneuver_Type_kSharpLeft:
+        subset = &dictionary_.sharp_subset;
+        break;
+      default:
+        throw std::runtime_error("Invalid TripDirections_Maneuver_Type in method FormTurnInstruction.");
+  }
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
@@ -973,7 +971,7 @@ std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver,
   // Assign the street names
   std::string street_names = FormStreetNames(
       maneuver, maneuver.street_names(),
-      &dictionary_.turn_subset.empty_street_name_labels, true);
+      &subset->empty_street_name_labels, true);
 
   // Assign the begin street names
   std::string begin_street_names = FormStreetNames(
@@ -993,12 +991,11 @@ std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver,
   }
 
   // Set instruction to the determined tagged phrase
-  instruction = dictionary_.turn_subset.phrases.at(std::to_string(phrase_id));
+  instruction = subset->phrases.at(std::to_string(phrase_id));
 
   // Replace phrase tags with values
   boost::replace_all(instruction, kRelativeDirectionTag,
-      FormRelativeTurnDirection(maneuver.type(),
-                                dictionary_.turn_subset.relative_directions));
+      FormRelativeTwoDirection(maneuver.type(), subset->relative_directions));
   boost::replace_all(instruction, kStreetNamesTag, street_names);
   boost::replace_all(instruction, kBeginStreetNamesTag, begin_street_names);
 
@@ -1008,11 +1005,11 @@ std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver,
 
 std::string NarrativeBuilder::FormVerbalAlertTurnInstruction(
     Maneuver& maneuver, Maneuver* prev_maneuver, uint32_t element_max_count,
-    std::string delim) {
-  // "0": "Turn <RELATIVE_DIRECTION>.",
-  // "1": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
-  // "2": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
-  // "3": "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+    const std::string& delim) {
+  // "0": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION>.",
+  // "1": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
+  // "2": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
+  // "3": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
 
   return FormVerbalTurnInstruction(maneuver, prev_maneuver, element_max_count,
                                    delim);
@@ -1020,11 +1017,29 @@ std::string NarrativeBuilder::FormVerbalAlertTurnInstruction(
 
 std::string NarrativeBuilder::FormVerbalTurnInstruction(
     Maneuver& maneuver, Maneuver* prev_maneuver, uint32_t element_max_count,
-    std::string delim) {
-  // "0": "Turn <RELATIVE_DIRECTION>.",
-  // "1": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
-  // "2": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
-  // "3": "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+    const std::string& delim) {
+  // "0": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION>.",
+  // "1": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
+  // "2": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
+  // "3": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+
+  const TurnSubset* subset = nullptr;
+  switch (maneuver.type()) {
+      case TripDirections_Maneuver_Type_kSlightRight:
+      case TripDirections_Maneuver_Type_kSlightLeft:
+        subset = &dictionary_.bear_verbal_subset;
+        break;
+      case TripDirections_Maneuver_Type_kRight:
+      case TripDirections_Maneuver_Type_kLeft:
+        subset = &dictionary_.turn_verbal_subset;
+        break;
+      case TripDirections_Maneuver_Type_kSharpRight:
+      case TripDirections_Maneuver_Type_kSharpLeft:
+        subset = &dictionary_.sharp_verbal_subset;
+        break;
+      default:
+        throw std::runtime_error("Invalid TripDirections_Maneuver_Type in method FormTurnInstruction.");
+  }
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
@@ -1032,13 +1047,13 @@ std::string NarrativeBuilder::FormVerbalTurnInstruction(
   // Assign the street names
   std::string street_names = FormStreetNames(
       maneuver, maneuver.street_names(),
-      &dictionary_.turn_verbal_subset.empty_street_name_labels, true,
+      &subset->empty_street_name_labels, true,
       element_max_count, delim, maneuver.verbal_formatter());
 
   // Assign the begin street names
   std::string begin_street_names = FormStreetNames(
       maneuver, maneuver.begin_street_names(),
-      &dictionary_.turn_verbal_subset.empty_street_name_labels, false,
+      &subset->empty_street_name_labels, false,
       element_max_count, delim, maneuver.verbal_formatter());
 
   // Determine which phrase to use
@@ -1055,120 +1070,12 @@ std::string NarrativeBuilder::FormVerbalTurnInstruction(
   }
 
   // Set instruction to the determined tagged phrase
-  instruction = dictionary_.turn_verbal_subset.phrases.at(std::to_string(phrase_id));
-
-  // Replace phrase tags with values
-  boost::replace_all(instruction, kRelativeDirectionTag,
-      FormRelativeTurnDirection(
-          maneuver.type(), dictionary_.turn_verbal_subset.relative_directions));
-  boost::replace_all(instruction, kStreetNamesTag, street_names);
-  boost::replace_all(instruction, kBeginStreetNamesTag, begin_street_names);
-
-  return instruction;
-
-}
-
-std::string NarrativeBuilder::FormBearInstruction(Maneuver& maneuver,
-                                                  Maneuver* prev_maneuver) {
-  // "0": "Bear <RELATIVE_DIRECTION>.",
-  // "1": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
-  // "2": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
-  // "3": "Bear <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
-
-  std::string instruction;
-  instruction.reserve(kInstructionInitialCapacity);
-
-  // Assign the street names
-  std::string street_names = FormStreetNames(
-      maneuver, maneuver.street_names(),
-      &dictionary_.bear_subset.empty_street_name_labels, true);
-
-  // Assign the begin street names
-  std::string begin_street_names = FormStreetNames(
-      maneuver, maneuver.begin_street_names());
-
-  // Determine which phrase to use
-  uint8_t phrase_id = 0;
-  if (!street_names.empty()) {
-    phrase_id = 1;
-  }
-  if (!begin_street_names.empty()) {
-    phrase_id = 2;
-  }
-  if (begin_street_names.empty()
-      && maneuver.HasSimilarNames(prev_maneuver, true)) {
-    phrase_id = 3;
-  }
-
-  // Set instruction to the determined tagged phrase
-  instruction = dictionary_.bear_subset.phrases.at(std::to_string(phrase_id));
-
-  // Replace phrase tags with values
-  boost::replace_all(instruction, kRelativeDirectionTag,
-      FormRelativeTwoDirection(maneuver.type(),
-                               dictionary_.bear_subset.relative_directions));
-  boost::replace_all(instruction, kStreetNamesTag, street_names);
-  boost::replace_all(instruction, kBeginStreetNamesTag, begin_street_names);
-
-  return instruction;
-
-}
-
-std::string NarrativeBuilder::FormVerbalAlertBearInstruction(
-    Maneuver& maneuver, Maneuver* prev_maneuver, uint32_t element_max_count,
-    std::string delim) {
-  // "0": "Bear <RELATIVE_DIRECTION>.",
-  // "1": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
-  // "2": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
-  // "3": "Bear <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
-
-  return FormVerbalBearInstruction(maneuver, prev_maneuver, element_max_count,
-                                   delim);
-}
-
-std::string NarrativeBuilder::FormVerbalBearInstruction(
-    Maneuver& maneuver, Maneuver* prev_maneuver, uint32_t element_max_count,
-    std::string delim) {
-  // "0": "Bear <RELATIVE_DIRECTION>.",
-  // "1": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
-  // "2": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
-  // "3": "Bear <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
-
-  std::string instruction;
-  instruction.reserve(kInstructionInitialCapacity);
-
-  // Assign the street names
-  std::string street_names = FormStreetNames(
-      maneuver, maneuver.street_names(),
-      &dictionary_.bear_verbal_subset.empty_street_name_labels, true,
-      element_max_count, delim, maneuver.verbal_formatter());
-
-  // Assign the begin street names
-  std::string begin_street_names = FormStreetNames(
-      maneuver, maneuver.begin_street_names(),
-      &dictionary_.bear_verbal_subset.empty_street_name_labels, false,
-      element_max_count, delim, maneuver.verbal_formatter());
-
-  // Determine which phrase to use
-  uint8_t phrase_id = 0;
-  if (!street_names.empty()) {
-    phrase_id = 1;
-  }
-  if (!begin_street_names.empty()) {
-    phrase_id = 2;
-  }
-  if (begin_street_names.empty()
-      && maneuver.HasSimilarNames(prev_maneuver, true)) {
-    phrase_id = 3;
-  }
-
-  // Set instruction to the determined tagged phrase
-  instruction = dictionary_.bear_verbal_subset.phrases.at(std::to_string(phrase_id));
+  instruction = subset->phrases.at(std::to_string(phrase_id));
 
   // Replace phrase tags with values
   boost::replace_all(instruction, kRelativeDirectionTag,
       FormRelativeTwoDirection(
-          maneuver.type(), dictionary_.bear_verbal_subset.relative_directions));
+          maneuver.type(), subset->relative_directions));
   boost::replace_all(instruction, kStreetNamesTag, street_names);
   boost::replace_all(instruction, kBeginStreetNamesTag, begin_street_names);
 
@@ -1224,7 +1131,7 @@ std::string NarrativeBuilder::FormUturnInstruction(Maneuver& maneuver,
 
 std::string NarrativeBuilder::FormVerbalAlertUturnInstruction(
     Maneuver& maneuver, Maneuver* prev_maneuver, uint32_t element_max_count,
-    std::string delim) {
+    const std::string& delim) {
   // "0": "Make a <RELATIVE_DIRECTION> U-turn.",
   // "1": "Make a <RELATIVE_DIRECTION> U-turn onto <STREET_NAMES>.",
   // "2": "Make a <RELATIVE_DIRECTION> U-turn to stay on <STREET_NAMES>.",
@@ -1275,7 +1182,7 @@ std::string NarrativeBuilder::FormVerbalAlertUturnInstruction(
 
 std::string NarrativeBuilder::FormVerbalUturnInstruction(
     Maneuver& maneuver, Maneuver* prev_maneuver, uint32_t element_max_count,
-    std::string delim) {
+    const std::string& delim) {
   // "0": "Make a <RELATIVE_DIRECTION> U-turn.",
   // "1": "Make a <RELATIVE_DIRECTION> U-turn onto <STREET_NAMES>.",
   // "2": "Make a <RELATIVE_DIRECTION> U-turn to stay on <STREET_NAMES>.",
@@ -1378,7 +1285,7 @@ std::string NarrativeBuilder::FormRampStraightInstruction(
 
 std::string NarrativeBuilder::FormVerbalAlertRampStraightInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
   // "0": "Stay straight to take the ramp.",
   // "1": "Stay straight to take the <BRANCH_SIGN> ramp.",
   // "2": "Stay straight to take the ramp toward <TOWARD_SIGN>.",
@@ -1426,7 +1333,7 @@ std::string NarrativeBuilder::FormVerbalAlertRampStraightInstruction(
 
 std::string NarrativeBuilder::FormVerbalRampStraightInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
   //  "0": "Stay straight to take the ramp.",
   //  "1": "Stay straight to take the <BRANCH_SIGN> ramp.",
   //  "2": "Stay straight to take the ramp toward <TOWARD_SIGN>.",
@@ -1542,7 +1449,7 @@ std::string NarrativeBuilder::FormRampInstruction(
 
 std::string NarrativeBuilder::FormVerbalAlertRampInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
   // "0": "Take the ramp on the <RELATIVE_DIRECTION>.",
   // "1": "Take the <BRANCH_SIGN> ramp on the <RELATIVE_DIRECTION>.",
   // "2": "Take the ramp on the <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
@@ -1593,7 +1500,7 @@ std::string NarrativeBuilder::FormVerbalAlertRampInstruction(
 
 std::string NarrativeBuilder::FormVerbalRampInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
   // "0": "Take the ramp on the <RELATIVE_DIRECTION>.",
   // "1": "Take the <BRANCH_SIGN> ramp on the <RELATIVE_DIRECTION>.",
   // "2": "Take the ramp on the <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
@@ -1733,7 +1640,7 @@ std::string NarrativeBuilder::FormExitInstruction(
 
 std::string NarrativeBuilder::FormVerbalAlertExitInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
   // "0": "Take the exit on the <RELATIVE_DIRECTION>.",
   // "1": "Take exit <NUMBER_SIGN> on the <RELATIVE_DIRECTION>.",
   // "2": "Take the <BRANCH_SIGN> exit on the <RELATIVE_DIRECTION>.",
@@ -1780,7 +1687,7 @@ std::string NarrativeBuilder::FormVerbalAlertExitInstruction(
 
 std::string NarrativeBuilder::FormVerbalExitInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
   // "0": "Take the exit on the <RELATIVE_DIRECTION>.",
   // "1": "Take exit <NUMBER_SIGN> on the <RELATIVE_DIRECTION>.",
   // "2": "Take the <BRANCH_SIGN> exit on the <RELATIVE_DIRECTION>.",
@@ -1919,7 +1826,7 @@ std::string NarrativeBuilder::FormKeepInstruction(
 
 std::string NarrativeBuilder::FormVerbalAlertKeepInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
 
   // "0": "Keep <RELATIVE_DIRECTION> at the fork.",
   // "1": "Keep <RELATIVE_DIRECTION> to take exit <NUMBER_SIGN>.",
@@ -1968,7 +1875,7 @@ std::string NarrativeBuilder::FormVerbalAlertKeepInstruction(
 
 std::string NarrativeBuilder::FormVerbalKeepInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
 
   // "0": "Keep <RELATIVE_DIRECTION> at the fork.",
   // "1": "Keep <RELATIVE_DIRECTION> to take exit <NUMBER_SIGN>.",
@@ -2092,7 +1999,7 @@ std::string NarrativeBuilder::FormKeepToStayOnInstruction(
 
 std::string NarrativeBuilder::FormVerbalAlertKeepToStayOnInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
 
   // "0": "Keep <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
 
@@ -2112,7 +2019,7 @@ std::string NarrativeBuilder::FormVerbalAlertKeepToStayOnInstruction(
 
 std::string NarrativeBuilder::FormVerbalKeepToStayOnInstruction(
     Maneuver& maneuver, bool limit_by_consecutive_count,
-    uint32_t element_max_count, std::string delim) {
+    uint32_t element_max_count, const std::string& delim) {
 
   // "0": "Keep <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
   // "1": "Keep <RELATIVE_DIRECTION> to take exit <NUMBER_SIGN> to stay on <STREET_NAMES>.",
@@ -2201,7 +2108,7 @@ std::string NarrativeBuilder::FormMergeInstruction(Maneuver& maneuver) {
 }
 
 std::string NarrativeBuilder::FormVerbalAlertMergeInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Merge.",
   // "1": "Merge onto <STREET_NAMES>."
 
@@ -2209,7 +2116,7 @@ std::string NarrativeBuilder::FormVerbalAlertMergeInstruction(
 }
 
 std::string NarrativeBuilder::FormVerbalMergeInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Merge.",
   // "1": "Merge onto <STREET_NAMES>."
 
@@ -2268,7 +2175,7 @@ std::string NarrativeBuilder::FormEnterRoundaboutInstruction(Maneuver& maneuver)
 }
 
 std::string NarrativeBuilder::FormVerbalAlertEnterRoundaboutInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Enter the roundabout.",
 
   std::string instruction;
@@ -2285,7 +2192,7 @@ std::string NarrativeBuilder::FormVerbalAlertEnterRoundaboutInstruction(
 }
 
 std::string NarrativeBuilder::FormVerbalEnterRoundaboutInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Enter the roundabout.",
   // "1": "Enter the roundabout and take the <ORDINAL_VALUE> exit."
 
@@ -2351,7 +2258,7 @@ std::string NarrativeBuilder::FormExitRoundaboutInstruction(Maneuver& maneuver) 
 }
 
 std::string NarrativeBuilder::FormVerbalExitRoundaboutInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Exit the roundabout.",
   // "1": "Exit the roundabout onto <STREET_NAMES>.",
   // "2": "Exit the roundabout onto <BEGIN_STREET_NAMES>."
@@ -2430,7 +2337,7 @@ std::string NarrativeBuilder::FormEnterFerryInstruction(Maneuver& maneuver) {
 }
 
 std::string NarrativeBuilder::FormVerbalAlertEnterFerryInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Take the Ferry.",
   // "1": "Take the <STREET_NAMES>.",
   // "2": "Take the <STREET_NAMES> <FERRY_LABEL>."
@@ -2439,7 +2346,7 @@ std::string NarrativeBuilder::FormVerbalAlertEnterFerryInstruction(
 }
 
 std::string NarrativeBuilder::FormVerbalEnterFerryInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Take the Ferry.",
   // "1": "Take the <STREET_NAMES>.",
   // "2": "Take the <STREET_NAMES> <FERRY_LABEL>."
@@ -2519,7 +2426,7 @@ std::string NarrativeBuilder::FormExitFerryInstruction(Maneuver& maneuver) {
 }
 
 std::string NarrativeBuilder::FormVerbalAlertExitFerryInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Head <CARDINAL_DIRECTION>.",
   // "1": "Head <CARDINAL_DIRECTION> on <STREET_NAMES>.",
   // "2": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>."
@@ -2528,7 +2435,7 @@ std::string NarrativeBuilder::FormVerbalAlertExitFerryInstruction(
 }
 
 std::string NarrativeBuilder::FormVerbalExitFerryInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Head <CARDINAL_DIRECTION>.",
   // "1": "Head <CARDINAL_DIRECTION> on <STREET_NAMES>.",
   // "2": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>."
@@ -3141,7 +3048,7 @@ std::string NarrativeBuilder::FormPostTransitConnectionDestinationInstruction(
 }
 
 std::string NarrativeBuilder::FormVerbalPostTransitConnectionDestinationInstruction(
-    Maneuver& maneuver, uint32_t element_max_count, std::string delim) {
+    Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // 0 "Head <FormCardinalDirection>."
   // 1 "Head <FormCardinalDirection> on <STREET_NAMES>."
   // 2 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
@@ -3192,7 +3099,7 @@ std::string NarrativeBuilder::FormVerbalPostTransitConnectionDestinationInstruct
 
 std::string NarrativeBuilder::FormVerbalPostTransitionInstruction(
     Maneuver& maneuver, bool include_street_names, uint32_t element_max_count,
-    std::string delim) {
+    const std::string& delim) {
   // "0": "Continue for <LENGTH>.",
   // "1": "Continue on <STREET_NAMES> for <LENGTH>."
 
@@ -3415,6 +3322,8 @@ std::string NarrativeBuilder::FormRelativeTwoDirection(
     TripDirections_Maneuver_Type type,
     const std::vector<std::string>& relative_directions) {
   switch (type) {
+    case TripDirections_Maneuver_Type_kLeft:
+    case TripDirections_Maneuver_Type_kSharpLeft:
     case TripDirections_Maneuver_Type_kSlightLeft:
     case TripDirections_Maneuver_Type_kUturnLeft:
     case TripDirections_Maneuver_Type_kRampLeft:
@@ -3422,6 +3331,8 @@ std::string NarrativeBuilder::FormRelativeTwoDirection(
     case TripDirections_Maneuver_Type_kDestinationLeft: {
       return relative_directions.at(0); // "left"
     }
+    case TripDirections_Maneuver_Type_kRight:
+    case TripDirections_Maneuver_Type_kSharpRight:
     case TripDirections_Maneuver_Type_kSlightRight:
     case TripDirections_Maneuver_Type_kUturnRight:
     case TripDirections_Maneuver_Type_kRampRight:
@@ -3452,29 +3363,6 @@ std::string NarrativeBuilder::FormRelativeThreeDirection(
     default: {
       throw std::runtime_error(
           "Invalid TripDirections_Maneuver_Type in method FormRelativeThreeDirection.");
-    }
-  }
-}
-
-std::string NarrativeBuilder::FormRelativeTurnDirection(
-    TripDirections_Maneuver_Type type,
-    const std::vector<std::string>& relative_directions) {
-  switch (type) {
-    case TripDirections_Maneuver_Type_kLeft: {
-      return relative_directions.at(0); // "left"
-    }
-    case TripDirections_Maneuver_Type_kSharpLeft: {
-      return relative_directions.at(1); // "sharp left"
-    }
-    case TripDirections_Maneuver_Type_kRight: {
-      return relative_directions.at(2); // "right"
-    }
-    case TripDirections_Maneuver_Type_kSharpRight: {
-      return relative_directions.at(3); // "sharp right"
-    }
-    default: {
-      throw std::runtime_error(
-          "Invalid TripDirections_Maneuver_Type in method FormRelativeTurnDirection.");
     }
   }
 }
@@ -3543,7 +3431,7 @@ std::string NarrativeBuilder::FormTransitName(Maneuver& maneuver) {
 // TODO remove after refactor
 std::string NarrativeBuilder::FormOldStreetNames(
     const Maneuver& maneuver, const StreetNames& street_names,
-    bool enhance_empty_street_names, uint32_t max_count, std::string delim,
+    bool enhance_empty_street_names, uint32_t max_count, const std::string& delim,
     const VerbalTextFormatter* verbal_formatter) {
   std::string street_names_string;
 
@@ -3585,7 +3473,7 @@ std::string NarrativeBuilder::FormOldStreetNames(
 std::string NarrativeBuilder::FormStreetNames(
     const Maneuver& maneuver, const StreetNames& street_names,
     const std::vector<std::string>* empty_street_name_labels,
-    bool enhance_empty_street_names, uint32_t max_count, std::string delim,
+    bool enhance_empty_street_names, uint32_t max_count, const std::string& delim,
     const VerbalTextFormatter* verbal_formatter) {
   std::string street_names_string;
 
@@ -3626,7 +3514,7 @@ std::string NarrativeBuilder::FormStreetNames(
 }
 
 std::string NarrativeBuilder::FormStreetNames(
-    const StreetNames& street_names, uint32_t max_count, std::string delim,
+    const StreetNames& street_names, uint32_t max_count, const std::string& delim,
     const VerbalTextFormatter* verbal_formatter) {
   std::string street_names_string;
   uint32_t count = 0;

--- a/test/narrative_dictionary.cc
+++ b/test/narrative_dictionary.cc
@@ -155,6 +155,16 @@ const std::map<std::string, std::string> kExpectedTransitConnectionStartVerbalPh
     {"1", "Enter the <TRANSIT_STOP> Station."}
 };
 
+const std::map<std::string, std::string> kExpectedTransitConnectionTransferPhrases = {
+    {"0", "Transfer at the station."},
+    {"1", "Transfer at the <TRANSIT_STOP> Station."}
+};
+
+const std::map<std::string, std::string> kExpectedTransitConnectionTransferVerbalPhrases = {
+    {"0", "Transfer at the station."},
+    {"1", "Transfer at the <TRANSIT_STOP> Station."}
+};
+
 
 const NarrativeDictionary& GetNarrativeDictionary(const std::string& lang_tag) {
   // Get the locale dictionary
@@ -1100,6 +1110,24 @@ void test_en_US_transit_connection_start_verbal() {
 
 }
 
+void test_en_US_transit_connection_transfer() {
+  const NarrativeDictionary& dictionary = GetNarrativeDictionary("en-US");
+
+  // Validate transit_connection_start phrases
+  validate(dictionary.transit_connection_transfer_subset,
+           kExpectedTransitConnectionTransferPhrases);
+
+}
+
+void test_en_US_transit_connection_transfer_verbal() {
+  const NarrativeDictionary& dictionary = GetNarrativeDictionary("en-US");
+
+  // Validate transit_connection_start_verbal phrases
+  validate(dictionary.transit_connection_transfer_verbal_subset,
+           kExpectedTransitConnectionTransferVerbalPhrases);
+
+}
+
 void test_en_US_post_transition_verbal_subset() {
   const NarrativeDictionary& dictionary = GetNarrativeDictionary("en-US");
 
@@ -1257,6 +1285,12 @@ int main() {
 
   // test the en-US transit_connection_start_verbal phrases
   suite.test(TEST_CASE(test_en_US_transit_connection_start_verbal));
+
+  // test the en-US transit_connection_transfer phrases
+  suite.test(TEST_CASE(test_en_US_transit_connection_transfer));
+
+  // test the en-US transit_connection_transfer_verbal phrases
+  suite.test(TEST_CASE(test_en_US_transit_connection_transfer_verbal));
 
   // test the en-US post_transition_verbal_subset phrases
   suite.test(TEST_CASE(test_en_US_post_transition_verbal_subset));

--- a/test/narrative_dictionary.cc
+++ b/test/narrative_dictionary.cc
@@ -19,7 +19,6 @@ const std::vector<std::string> kExpectedMetricLengths = { "<KILOMETERS> kilomete
 const std::vector<std::string> kExpectedUsCustomaryLengths = { "<MILES> miles", "1 mile", "a half mile", "<TENTHS_OF_MILE> tenths of a mile", "1 tenth of a mile", "<FEET> feet", "less than 10 feet" };
 const std::vector<std::string> kExpectedRelativeTwoDirections = { "left", "right" };
 const std::vector<std::string> kExpectedRelativeThreeDirections = { "left", "straight", "right" };
-const std::vector<std::string> kExpectedRelativeTurnDirections = { "left", "sharp left", "right", "sharp right" };
 const std::vector<std::string> kExpectedOrdinalValues = { "1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th" };
 const std::string kExpectedFerryLabel = "Ferry";
 
@@ -468,7 +467,7 @@ void test_en_US_turn() {
 
   // relative_directions
   const auto& relative_directions = dictionary.turn_subset.relative_directions;
-  validate(relative_directions, kExpectedRelativeTurnDirections);
+  validate(relative_directions, kExpectedRelativeTwoDirections);
 
   // empty_street_name_labels "walkway", "cycleway", "mountain bike trail"
   const auto& empty_street_name_labels = dictionary.turn_subset.empty_street_name_labels;
@@ -497,10 +496,68 @@ void test_en_US_turn_verbal() {
 
   // relative_directions
   const auto& relative_directions = dictionary.turn_verbal_subset.relative_directions;
-  validate(relative_directions, kExpectedRelativeTurnDirections);
+  validate(relative_directions, kExpectedRelativeTwoDirections);
 
   // empty_street_name_labels "walkway", "cycleway", "mountain bike trail"
   const auto& empty_street_name_labels = dictionary.turn_verbal_subset.empty_street_name_labels;
+  validate(empty_street_name_labels, kExpectedEmptyStreetNameLabels);
+
+}
+
+void test_en_US_sharp() {
+  const NarrativeDictionary& dictionary = GetNarrativeDictionary("en-US");
+
+  // "0": "Turn sharp <RELATIVE_DIRECTION>.",
+  const auto& phrase_0 = dictionary.sharp_subset.phrases.at("0");
+  validate(phrase_0, "Turn sharp <RELATIVE_DIRECTION>.");
+
+  // "1": "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
+  const auto& phrase_1 = dictionary.sharp_subset.phrases.at("1");
+  validate(phrase_1, "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.");
+
+  // "2": "Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
+  const auto& phrase_2 = dictionary.sharp_subset.phrases.at("2");
+  validate(phrase_2, "Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.");
+
+  // "3": "Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+  const auto& phrase_3 = dictionary.sharp_subset.phrases.at("3");
+  validate(phrase_3, "Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.");
+
+  // relative_directions
+  const auto& relative_directions = dictionary.sharp_subset.relative_directions;
+  validate(relative_directions, kExpectedRelativeTwoDirections);
+
+  // empty_street_name_labels "walkway", "cycleway", "mountain bike trail"
+  const auto& empty_street_name_labels = dictionary.sharp_subset.empty_street_name_labels;
+  validate(empty_street_name_labels, kExpectedEmptyStreetNameLabels);
+
+}
+
+void test_en_US_sharp_verbal() {
+  const NarrativeDictionary& dictionary = GetNarrativeDictionary("en-US");
+
+  // "0": "Turn sharp <RELATIVE_DIRECTION>.",
+  const auto& phrase_0 = dictionary.sharp_verbal_subset.phrases.at("0");
+  validate(phrase_0, "Turn sharp <RELATIVE_DIRECTION>.");
+
+  // "1": "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
+  const auto& phrase_1 = dictionary.sharp_verbal_subset.phrases.at("1");
+  validate(phrase_1, "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.");
+
+  // "2": "Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
+  const auto& phrase_2 = dictionary.sharp_verbal_subset.phrases.at("2");
+  validate(phrase_2, "Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.");
+
+  // "3": "Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+  const auto& phrase_3 = dictionary.sharp_verbal_subset.phrases.at("3");
+  validate(phrase_3, "Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.");
+
+  // relative_directions
+  const auto& relative_directions = dictionary.sharp_verbal_subset.relative_directions;
+  validate(relative_directions, kExpectedRelativeTwoDirections);
+
+  // empty_street_name_labels "walkway", "cycleway", "mountain bike trail"
+  const auto& empty_street_name_labels = dictionary.sharp_verbal_subset.empty_street_name_labels;
   validate(empty_street_name_labels, kExpectedEmptyStreetNameLabels);
 
 }
@@ -1088,6 +1145,12 @@ int main() {
 
   // test the en-US turn verbal phrases
   suite.test(TEST_CASE(test_en_US_turn_verbal));
+
+  // test the en-US sharp phrases
+  suite.test(TEST_CASE(test_en_US_sharp));
+
+  // test the en-US sharp verbal phrases
+  suite.test(TEST_CASE(test_en_US_sharp_verbal));
 
   // test the en-US uturn phrases
   suite.test(TEST_CASE(test_en_US_uturn));

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -377,6 +377,71 @@ void PopulateTurnManeuverList_0(std::list<Maneuver>& maneuvers,
                    0, 0, 1, 1, "", "", "", 0);
 }
 
+void PopulateTurnManeuverList_1(std::list<Maneuver>& maneuvers,
+                                const std::string& country_code,
+                                const std::string& state_code) {
+  maneuvers.emplace_back();
+  Maneuver& maneuver = maneuvers.back();
+  PopulateManeuver(maneuver, country_code, state_code,
+                   TripDirections_Maneuver_Type_kRight,
+                   { "Flatbush Avenue" }, { }, { }, "", 0.192229, 44, 89,
+                   Maneuver::RelativeDirection::kRight,
+                   TripDirections_Maneuver_CardinalDirection_kNorthWest, 322,
+                   322, 1, 4, 1, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { }, 1, 0, 0, 0, 1, 1, "", "", "", 0);
+}
+
+void PopulateTurnManeuverList_2(std::list<Maneuver>& maneuvers,
+                                const std::string& country_code,
+                                const std::string& state_code) {
+  maneuvers.emplace_back();
+  Maneuver& maneuver = maneuvers.back();
+  PopulateManeuver(maneuver, country_code, state_code,
+                   TripDirections_Maneuver_Type_kLeft, { "MD 924" }, {
+                       "North Bond Street", "US 1 Business", "MD 924" },
+                   { }, "", 0.840369, 111, 282,
+                   Maneuver::RelativeDirection::kLeft,
+                   TripDirections_Maneuver_CardinalDirection_kSouthEast, 141,
+                   144, 2, 16, 2, 27, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { }, 0, 1, 0, 0, 1, 0, "", "", "", 0);
+}
+
+void PopulateTurnManeuverList_3(std::list<Maneuver>& maneuvers,
+                                const std::string& country_code,
+                                const std::string& state_code) {
+  maneuvers.emplace_back();
+  Maneuver& maneuver1 = maneuvers.back();
+  PopulateManeuver(maneuver1, country_code, state_code,
+                   TripDirections_Maneuver_Type_kRight, { "Sunstone Drive" },
+                   { }, { }, "", 0.077000, 49, 89,
+                   Maneuver::RelativeDirection::kRight,
+                   TripDirections_Maneuver_CardinalDirection_kEast, 75, 77, 1,
+                   3, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { }, 1, 0,
+                   0, 0, 1, 1, "", "", "", 0);
+  maneuvers.emplace_back();
+  Maneuver& maneuver2 = maneuvers.back();
+  PopulateManeuver(maneuver2, country_code, state_code,
+                   TripDirections_Maneuver_Type_kRight, { "Sunstone Drive" },
+                   { }, { }, "", 0.038000, 12, 90,
+                   Maneuver::RelativeDirection::kRight,
+                   TripDirections_Maneuver_CardinalDirection_kSouth, 167, 167,
+                   3, 4, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { }, 1,
+                   0, 0, 0, 1, 0, "", "", "", 1);
+}
+
+void PopulateSharpManeuverList_0(std::list<Maneuver>& maneuvers,
+                                const std::string& country_code,
+                                const std::string& state_code) {
+  maneuvers.emplace_back();
+  Maneuver& maneuver = maneuvers.back();
+  PopulateManeuver(maneuver, country_code, state_code,
+                   TripDirections_Maneuver_Type_kSharpLeft, { }, { }, { }, "",
+                   0.824000, 60, 201, Maneuver::RelativeDirection::kLeft,
+                   TripDirections_Maneuver_CardinalDirection_kWest, 260, 268, 1,
+                   2, 1, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { }, 0, 1,
+                   0, 0, 1, 1, "", "", "", 0);
+}
+
 void PopulateSharpManeuverList_1(std::list<Maneuver>& maneuvers,
                                 const std::string& country_code,
                                 const std::string& state_code) {
@@ -406,14 +471,14 @@ void PopulateSharpManeuverList_2(std::list<Maneuver>& maneuvers,
                    { }, 0, 1, 0, 0, 1, 0, "", "", "", 0);
 }
 
-void PopulateTurnManeuverList_3(std::list<Maneuver>& maneuvers,
+void PopulateSharpManeuverList_3(std::list<Maneuver>& maneuvers,
                                 const std::string& country_code,
                                 const std::string& state_code) {
   maneuvers.emplace_back();
   Maneuver& maneuver1 = maneuvers.back();
   PopulateManeuver(maneuver1, country_code, state_code,
-                   TripDirections_Maneuver_Type_kRight, { "Sunstone Drive" },
-                   { }, { }, "", 0.077000, 49, 89,
+                   TripDirections_Maneuver_Type_kSharpRight, { "Sunstone Drive" },
+                   { }, { }, "", 0.077000, 49, 147,
                    Maneuver::RelativeDirection::kRight,
                    TripDirections_Maneuver_CardinalDirection_kEast, 75, 77, 1,
                    3, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { }, 1, 0,
@@ -421,8 +486,8 @@ void PopulateTurnManeuverList_3(std::list<Maneuver>& maneuvers,
   maneuvers.emplace_back();
   Maneuver& maneuver2 = maneuvers.back();
   PopulateManeuver(maneuver2, country_code, state_code,
-                   TripDirections_Maneuver_Type_kRight, { "Sunstone Drive" },
-                   { }, { }, "", 0.038000, 12, 90,
+                   TripDirections_Maneuver_Type_kSharpRight, { "Sunstone Drive" },
+                   { }, { }, "", 0.038000, 12, 149,
                    Maneuver::RelativeDirection::kRight,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 167, 167,
                    3, 4, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { }, 1,
@@ -1928,6 +1993,133 @@ void TestBuildTurnInstructions_0_miles_en_US() {
 
 ///////////////////////////////////////////////////////////////////////////////
 // FormTurnInstruction
+// 1 "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES>."
+// 1 "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES(1)>."
+// 1 "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES(2)>."
+void TestBuildTurnInstructions_1_miles_en_US() {
+  std::string country_code = "US";
+  std::string state_code = "NY";
+
+  // Configure directions options
+  DirectionsOptions directions_options;
+  directions_options.set_units(DirectionsOptions_Units_kMiles);
+  directions_options.set_language("en-US");
+
+  // Configure maneuvers
+  std::list<Maneuver> maneuvers;
+  PopulateTurnManeuverList_1(maneuvers, country_code, state_code);
+
+  // Configure expected maneuvers based on directions options
+  std::list<Maneuver> expected_maneuvers;
+  PopulateTurnManeuverList_1(expected_maneuvers, country_code, state_code);
+  SetExpectedManeuverInstructions(expected_maneuvers,
+                                  "Turn right onto Flatbush Avenue.",
+                                  "Turn right onto Flatbush Avenue.",
+                                  "Turn right onto Flatbush Avenue.",
+                                  "Continue for 1 tenth of a mile.");
+
+  TryBuild(directions_options, maneuvers, expected_maneuvers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FormTurnInstruction
+// 2 "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
+// 2 "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES(1)>."
+// 2 "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES(2)>."
+void TestBuildTurnInstructions_2_miles_en_US() {
+  std::string country_code = "US";
+  std::string state_code = "MD";
+
+  // Configure directions options
+  DirectionsOptions directions_options;
+  directions_options.set_units(DirectionsOptions_Units_kMiles);
+  directions_options.set_language("en-US");
+
+  // Configure maneuvers
+  std::list<Maneuver> maneuvers;
+  PopulateTurnManeuverList_2(maneuvers, country_code, state_code);
+
+  // Configure expected maneuvers based on directions options
+  std::list<Maneuver> expected_maneuvers;
+  PopulateTurnManeuverList_2(expected_maneuvers, country_code, state_code);
+  SetExpectedManeuverInstructions(
+      expected_maneuvers,
+      "Turn left onto North Bond Street/US 1 Business/MD 924. Continue on MD 924.",
+      "Turn left onto North Bond Street.",
+      "Turn left onto North Bond Street, U.S. 1 Business.",
+      "Continue on Maryland 9 24 for a half mile.");
+
+  TryBuild(directions_options, maneuvers, expected_maneuvers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FormTurnInstruction
+// 3 "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+// 3 "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES(1)>."
+// 3 "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES(2)>."
+void TestBuildTurnInstructions_3_miles_en_US() {
+  std::string country_code = "US";
+  std::string state_code = "VA";
+
+  // Configure directions options
+  DirectionsOptions directions_options;
+  directions_options.set_units(DirectionsOptions_Units_kMiles);
+  directions_options.set_language("en-US");
+
+  // Configure maneuvers
+  std::list<Maneuver> maneuvers;
+  PopulateTurnManeuverList_3(maneuvers, country_code, state_code);
+
+  // Configure expected maneuvers based on directions options
+  std::list<Maneuver> expected_maneuvers;
+  PopulateTurnManeuverList_3(expected_maneuvers, country_code, state_code);
+  SetExpectedPreviousManeuverInstructions(
+      expected_maneuvers,
+      "Turn right onto Sunstone Drive.",
+      "Turn right onto Sunstone Drive.",
+      "Turn right onto Sunstone Drive. Then Turn right to stay on Sunstone Drive.",
+      "Continue for 300 feet.");
+  SetExpectedManeuverInstructions(expected_maneuvers,
+                                  "Turn right to stay on Sunstone Drive.",
+                                  "Turn right to stay on Sunstone Drive.",
+                                  "Turn right to stay on Sunstone Drive.",
+                                  "Continue for 100 feet.");
+
+  TryBuild(directions_options, maneuvers, expected_maneuvers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FormTurnInstruction
+// 0 "Turn sharp <RELATIVE_DIRECTION>."
+// 0 "Turn sharp <RELATIVE_DIRECTION>."
+// 0 "Turn sharp <RELATIVE_DIRECTION>."
+void TestBuildSharpInstructions_0_miles_en_US() {
+  std::string country_code = "US";
+  std::string state_code = "PA";
+
+  // Configure directions options
+  DirectionsOptions directions_options;
+  directions_options.set_units(DirectionsOptions_Units_kMiles);
+  directions_options.set_language("en-US");
+
+  // Configure maneuvers
+  std::list<Maneuver> maneuvers;
+  PopulateSharpManeuverList_0(maneuvers, country_code, state_code);
+
+  // Configure expected maneuvers based on directions options
+  std::list<Maneuver> expected_maneuvers;
+  PopulateSharpManeuverList_0(expected_maneuvers, country_code, state_code);
+  SetExpectedManeuverInstructions(expected_maneuvers,
+                                  "Turn sharp left.",
+                                  "Turn sharp left.",
+                                  "Turn sharp left.",
+                                  "Continue for a half mile.");
+
+  TryBuild(directions_options, maneuvers, expected_maneuvers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FormTurnInstruction
 // 1 "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>."
 // 1 "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES(1)>."
 // 1 "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES(2)>."
@@ -1989,10 +2181,10 @@ void TestBuildSharpInstructions_2_miles_en_US() {
 
 ///////////////////////////////////////////////////////////////////////////////
 // FormTurnInstruction
-// 3 "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
-// 3 "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES(1)>."
-// 3 "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES(2)>."
-void TestBuildTurnInstructions_3_miles_en_US() {
+// 3 "Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+// 3 "Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES(1)>."
+// 3 "Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES(2)>."
+void TestBuildSharpInstructions_3_miles_en_US() {
   std::string country_code = "US";
   std::string state_code = "VA";
 
@@ -2003,11 +2195,11 @@ void TestBuildTurnInstructions_3_miles_en_US() {
 
   // Configure maneuvers
   std::list<Maneuver> maneuvers;
-  PopulateTurnManeuverList_3(maneuvers, country_code, state_code);
+  PopulateSharpManeuverList_3(maneuvers, country_code, state_code);
 
   // Configure expected maneuvers based on directions options
   std::list<Maneuver> expected_maneuvers;
-  PopulateTurnManeuverList_3(expected_maneuvers, country_code, state_code);
+  PopulateSharpManeuverList_3(expected_maneuvers, country_code, state_code);
   SetExpectedPreviousManeuverInstructions(
       expected_maneuvers,
       "Turn right onto Sunstone Drive.",
@@ -2015,13 +2207,15 @@ void TestBuildTurnInstructions_3_miles_en_US() {
       "Turn right onto Sunstone Drive. Then Turn right to stay on Sunstone Drive.",
       "Continue for 300 feet.");
   SetExpectedManeuverInstructions(expected_maneuvers,
-                                  "Turn right to stay on Sunstone Drive.",
-                                  "Turn right to stay on Sunstone Drive.",
-                                  "Turn right to stay on Sunstone Drive.",
+                                  "Turn sharp right to stay on Sunstone Drive.",
+                                  "Turn sharp right to stay on Sunstone Drive.",
+                                  "Turn sharp right to stay on Sunstone Drive.",
                                   "Continue for 100 feet.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
 }
+
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // FormBearInstruction
@@ -5092,13 +5286,25 @@ int main() {
   suite.test(TEST_CASE(TestBuildTurnInstructions_0_miles_en_US));
 
   // BuildTurnInstructions_1_miles_en_US
-  suite.test(TEST_CASE(TestBuildSharpInstructions_1_miles_en_US));
+  suite.test(TEST_CASE(TestBuildTurnInstructions_1_miles_en_US));
 
   // BuildTurnInstructions_2_miles_en_US
-  suite.test(TEST_CASE(TestBuildSharpInstructions_2_miles_en_US));
+  suite.test(TEST_CASE(TestBuildTurnInstructions_2_miles_en_US));
 
   // BuildTurnInstructions_3_miles_en_US
   suite.test(TEST_CASE(TestBuildTurnInstructions_3_miles_en_US));
+
+  // BuildSharpInstructions_0_miles_en_US
+  suite.test(TEST_CASE(TestBuildSharpInstructions_0_miles_en_US));
+
+  // BuildSharpInstructions_1_miles_en_US
+  suite.test(TEST_CASE(TestBuildSharpInstructions_1_miles_en_US));
+
+  // BuildSharpInstructions_2_miles_en_US
+  suite.test(TEST_CASE(TestBuildSharpInstructions_2_miles_en_US));
+
+  // BuildSharpInstructions_0_miles_en_US
+  suite.test(TEST_CASE(TestBuildSharpInstructions_0_miles_en_US));
 
   // BuildBearInstructions_0_miles_en_US
   suite.test(TEST_CASE(TestBuildBearInstructions_0_miles_en_US));

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -377,7 +377,7 @@ void PopulateTurnManeuverList_0(std::list<Maneuver>& maneuvers,
                    0, 0, 1, 1, "", "", "", 0);
 }
 
-void PopulateTurnManeuverList_1(std::list<Maneuver>& maneuvers,
+void PopulateSharpManeuverList_1(std::list<Maneuver>& maneuvers,
                                 const std::string& country_code,
                                 const std::string& state_code) {
   maneuvers.emplace_back();
@@ -391,7 +391,7 @@ void PopulateTurnManeuverList_1(std::list<Maneuver>& maneuvers,
                    { }, 1, 0, 0, 0, 1, 1, "", "", "", 0);
 }
 
-void PopulateTurnManeuverList_2(std::list<Maneuver>& maneuvers,
+void PopulateSharpManeuverList_2(std::list<Maneuver>& maneuvers,
                                 const std::string& country_code,
                                 const std::string& state_code) {
   maneuvers.emplace_back();
@@ -1928,10 +1928,10 @@ void TestBuildTurnInstructions_0_miles_en_US() {
 
 ///////////////////////////////////////////////////////////////////////////////
 // FormTurnInstruction
-// 1 "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES>."
-// 1 "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES(1)>."
-// 1 "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES(2)>."
-void TestBuildTurnInstructions_1_miles_en_US() {
+// 1 "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>."
+// 1 "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES(1)>."
+// 1 "Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES(2)>."
+void TestBuildSharpInstructions_1_miles_en_US() {
   std::string country_code = "US";
   std::string state_code = "NY";
 
@@ -1942,11 +1942,11 @@ void TestBuildTurnInstructions_1_miles_en_US() {
 
   // Configure maneuvers
   std::list<Maneuver> maneuvers;
-  PopulateTurnManeuverList_1(maneuvers, country_code, state_code);
+  PopulateSharpManeuverList_1(maneuvers, country_code, state_code);
 
   // Configure expected maneuvers based on directions options
   std::list<Maneuver> expected_maneuvers;
-  PopulateTurnManeuverList_1(expected_maneuvers, country_code, state_code);
+  PopulateSharpManeuverList_1(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(expected_maneuvers,
                                   "Turn sharp right onto Flatbush Avenue.",
                                   "Turn sharp right onto Flatbush Avenue.",
@@ -1958,10 +1958,10 @@ void TestBuildTurnInstructions_1_miles_en_US() {
 
 ///////////////////////////////////////////////////////////////////////////////
 // FormTurnInstruction
-// 2 "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
-// 2 "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES(1)>."
-// 2 "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES(2)>."
-void TestBuildTurnInstructions_2_miles_en_US() {
+// 2 "Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
+// 2 "Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES(1)>."
+// 2 "Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES(2)>."
+void TestBuildSharpInstructions_2_miles_en_US() {
   std::string country_code = "US";
   std::string state_code = "MD";
 
@@ -1972,11 +1972,11 @@ void TestBuildTurnInstructions_2_miles_en_US() {
 
   // Configure maneuvers
   std::list<Maneuver> maneuvers;
-  PopulateTurnManeuverList_2(maneuvers, country_code, state_code);
+  PopulateSharpManeuverList_2(maneuvers, country_code, state_code);
 
   // Configure expected maneuvers based on directions options
   std::list<Maneuver> expected_maneuvers;
-  PopulateTurnManeuverList_2(expected_maneuvers, country_code, state_code);
+  PopulateSharpManeuverList_2(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(
       expected_maneuvers,
       "Turn sharp left onto North Bond Street/US 1 Business/MD 924. Continue on MD 924.",
@@ -5092,10 +5092,10 @@ int main() {
   suite.test(TEST_CASE(TestBuildTurnInstructions_0_miles_en_US));
 
   // BuildTurnInstructions_1_miles_en_US
-  suite.test(TEST_CASE(TestBuildTurnInstructions_1_miles_en_US));
+  suite.test(TEST_CASE(TestBuildSharpInstructions_1_miles_en_US));
 
   // BuildTurnInstructions_2_miles_en_US
-  suite.test(TEST_CASE(TestBuildTurnInstructions_2_miles_en_US));
+  suite.test(TEST_CASE(TestBuildSharpInstructions_2_miles_en_US));
 
   // BuildTurnInstructions_3_miles_en_US
   suite.test(TEST_CASE(TestBuildTurnInstructions_3_miles_en_US));

--- a/valhalla/odin/narrative_dictionary.h
+++ b/valhalla/odin/narrative_dictionary.h
@@ -50,6 +50,8 @@ constexpr auto kExitFerryKey = "instructions.exit_ferry";
 constexpr auto kExitFerryVerbalKey = "instructions.exit_ferry_verbal";
 constexpr auto kTransitConnectionStartKey = "instructions.transit_connection_start";
 constexpr auto kTransitConnectionStartVerbalKey = "instructions.transit_connection_start_verbal";
+constexpr auto kTransitConnectionTransferKey = "instructions.transit_connection_transfer";
+constexpr auto kTransitConnectionTransferVerbalKey = "instructions.transit_connection_transfer_verbal";
 constexpr auto kPostTransitionVerbalKey = "instructions.post_transition_verbal";
 constexpr auto kVerbalMultiCueKey = "instructions.verbal_multi_cue";
 
@@ -250,6 +252,10 @@ class NarrativeDictionary {
   // TransitConnectionStart
   PhraseSet transit_connection_start_subset;
   PhraseSet transit_connection_start_verbal_subset;
+
+  // TransitConnectionStart
+  PhraseSet transit_connection_transfer_subset;
+  PhraseSet transit_connection_transfer_verbal_subset;
 
   // Post transition verbal
   PostTransitionVerbalSubset post_transition_verbal_subset;

--- a/valhalla/odin/narrative_dictionary.h
+++ b/valhalla/odin/narrative_dictionary.h
@@ -22,6 +22,8 @@ constexpr auto kBearKey = "instructions.bear";
 constexpr auto kBearVerbalKey = "instructions.bear_verbal";
 constexpr auto kTurnKey = "instructions.turn";
 constexpr auto kTurnVerbalKey = "instructions.turn_verbal";
+constexpr auto kSharpKey = "instructions.sharp";
+constexpr auto kSharpVerbalKey = "instructions.sharp_verbal";
 constexpr auto kUturnKey = "instructions.uturn";
 constexpr auto kUturnVerbalAlertKey = "instructions.uturn_verbal_alert";
 constexpr auto kUturnVerbalKey = "instructions.uturn_verbal";
@@ -191,6 +193,10 @@ class NarrativeDictionary {
   // Turn
   TurnSubset turn_subset;
   TurnSubset turn_verbal_subset;
+
+  // Sharp
+  TurnSubset sharp_subset;
+  TurnSubset sharp_verbal_subset;
 
   // Uturn
   TurnSubset uturn_subset;

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -39,7 +39,7 @@ class NarrativeBuilder {
   std::string FormVerbalStartInstruction(Maneuver& maneuver,
                                          uint32_t element_max_count =
                                              kVerbalPreElementMaxCount,
-                                         std::string delim = kVerbalDelim);
+                                         const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormDestinationInstruction(Maneuver& maneuver);
@@ -56,7 +56,7 @@ class NarrativeBuilder {
                                            Maneuver* prev_maneuver,
                                            uint32_t element_max_count =
                                                kVerbalPreElementMaxCount,
-                                           std::string delim = kVerbalDelim);
+                                           const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormContinueInstruction(Maneuver& maneuver);
@@ -64,13 +64,13 @@ class NarrativeBuilder {
   std::string FormVerbalAlertContinueInstruction(
       Maneuver& maneuver, uint32_t element_max_count =
           kVerbalAlertElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalContinueInstruction(Maneuver& maneuver,
                                             DirectionsOptions_Units units,
                                             uint32_t element_max_count =
                                                 kVerbalPreElementMaxCount,
-                                            std::string delim = kVerbalDelim);
+                                            const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormTurnInstruction(Maneuver& maneuver, Maneuver* prev_maneuver);
@@ -79,28 +79,13 @@ class NarrativeBuilder {
                                              Maneuver* prev_maneuver,
                                              uint32_t element_max_count =
                                                  kVerbalAlertElementMaxCount,
-                                             std::string delim = kVerbalDelim);
+                                             const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalTurnInstruction(Maneuver& maneuver,
                                         Maneuver* prev_maneuver,
                                         uint32_t element_max_count =
                                             kVerbalPreElementMaxCount,
-                                        std::string delim = kVerbalDelim);
-
-  /////////////////////////////////////////////////////////////////////////////
-  std::string FormBearInstruction(Maneuver& maneuver, Maneuver* prev_maneuver);
-
-  std::string FormVerbalAlertBearInstruction(Maneuver& maneuver,
-                                             Maneuver* prev_maneuver,
-                                             uint32_t element_max_count =
-                                                 kVerbalAlertElementMaxCount,
-                                             std::string delim = kVerbalDelim);
-
-  std::string FormVerbalBearInstruction(Maneuver& maneuver,
-                                        Maneuver* prev_maneuver,
-                                        uint32_t element_max_count =
-                                            kVerbalPreElementMaxCount,
-                                        std::string delim = kVerbalDelim);
+                                        const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormUturnInstruction(Maneuver& maneuver, Maneuver* prev_maneuver);
@@ -109,13 +94,13 @@ class NarrativeBuilder {
                                               Maneuver* prev_maneuver,
                                               uint32_t element_max_count =
                                                   kVerbalAlertElementMaxCount,
-                                              std::string delim = kVerbalDelim);
+                                              const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalUturnInstruction(Maneuver& maneuver,
                                          Maneuver* prev_maneuver,
                                          uint32_t element_max_count =
                                              kVerbalPreElementMaxCount,
-                                         std::string delim = kVerbalDelim);
+                                         const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormRampStraightInstruction(Maneuver& maneuver,
@@ -128,13 +113,13 @@ class NarrativeBuilder {
       Maneuver& maneuver, bool limit_by_consecutive_count =
           kLimitByConseuctiveCount,
       uint32_t element_max_count = kVerbalAlertElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalRampStraightInstruction(
       Maneuver& maneuver, bool limit_by_consecutive_count =
           kLimitByConseuctiveCount,
       uint32_t element_max_count = kVerbalPreElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormRampInstruction(
@@ -147,14 +132,14 @@ class NarrativeBuilder {
                                                  kLimitByConseuctiveCount,
                                              uint32_t element_max_count =
                                                  kVerbalAlertElementMaxCount,
-                                             std::string delim = kVerbalDelim);
+                                             const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalRampInstruction(Maneuver& maneuver,
                                         bool limit_by_consecutive_count =
                                             kLimitByConseuctiveCount,
                                         uint32_t element_max_count =
                                             kVerbalPreElementMaxCount,
-                                        std::string delim = kVerbalDelim);
+                                        const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalRampInstruction(uint8_t phrase_id,
                                         const std::string& relative_dir,
@@ -173,14 +158,14 @@ class NarrativeBuilder {
                                                  kLimitByConseuctiveCount,
                                              uint32_t element_max_count =
                                                  kVerbalAlertElementMaxCount,
-                                             std::string delim = kVerbalDelim);
+                                             const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalExitInstruction(Maneuver& maneuver,
                                         bool limit_by_consecutive_count =
                                             kLimitByConseuctiveCount,
                                         uint32_t element_max_count =
                                             kVerbalPreElementMaxCount,
-                                        std::string delim = kVerbalDelim);
+                                        const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalExitInstruction(uint8_t phrase_id,
                                         const std::string& relative_dir,
@@ -200,14 +185,14 @@ class NarrativeBuilder {
                                                  kLimitByConseuctiveCount,
                                              uint32_t element_max_count =
                                                  kVerbalAlertElementMaxCount,
-                                             std::string delim = kVerbalDelim);
+                                             const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalKeepInstruction(Maneuver& maneuver,
                                         bool limit_by_consecutive_count =
                                             kLimitByConseuctiveCount,
                                         uint32_t element_max_count =
                                             kVerbalPreElementMaxCount,
-                                        std::string delim = kVerbalDelim);
+                                        const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalKeepInstruction(uint8_t phrase_id,
                                         const std::string& relative_dir,
@@ -226,13 +211,13 @@ class NarrativeBuilder {
       Maneuver& maneuver, bool limit_by_consecutive_count =
           kLimitByConseuctiveCount,
       uint32_t element_max_count = kVerbalAlertElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalKeepToStayOnInstruction(
       Maneuver& maneuver, bool limit_by_consecutive_count =
           kLimitByConseuctiveCount,
       uint32_t element_max_count = kVerbalPreElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalKeepToStayOnInstruction(
       uint8_t phrase_id, const std::string& relative_dir,
@@ -245,12 +230,12 @@ class NarrativeBuilder {
   std::string FormVerbalAlertMergeInstruction(Maneuver& maneuver,
                                               uint32_t element_max_count =
                                                   kVerbalAlertElementMaxCount,
-                                              std::string delim = kVerbalDelim);
+                                              const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalMergeInstruction(Maneuver& maneuver,
                                          uint32_t element_max_count =
                                              kVerbalPreElementMaxCount,
-                                         std::string delim = kVerbalDelim);
+                                         const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormEnterRoundaboutInstruction(Maneuver& maneuver);
@@ -258,12 +243,12 @@ class NarrativeBuilder {
   std::string FormVerbalAlertEnterRoundaboutInstruction(
       Maneuver& maneuver, uint32_t element_max_count =
           kVerbalAlertElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalEnterRoundaboutInstruction(
       Maneuver& maneuver,
       uint32_t element_max_count = kVerbalPreElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormExitRoundaboutInstruction(Maneuver& maneuver);
@@ -271,7 +256,7 @@ class NarrativeBuilder {
   std::string FormVerbalExitRoundaboutInstruction(Maneuver& maneuver,
                                                   uint32_t element_max_count =
                                                       kVerbalPreElementMaxCount,
-                                                  std::string delim =
+                                                  const std::string& delim =
                                                       kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
@@ -283,12 +268,12 @@ class NarrativeBuilder {
   std::string FormVerbalAlertEnterFerryInstruction(
       Maneuver& maneuver, uint32_t element_max_count =
           kVerbalAlertElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalEnterFerryInstruction(Maneuver& maneuver,
                                               uint32_t element_max_count =
                                                   kVerbalPreElementMaxCount,
-                                              std::string delim = kVerbalDelim);
+                                              const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormExitFerryInstruction(Maneuver& maneuver);
@@ -296,12 +281,12 @@ class NarrativeBuilder {
   std::string FormVerbalAlertExitFerryInstruction(
       Maneuver& maneuver, uint32_t element_max_count =
           kVerbalAlertElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalExitFerryInstruction(Maneuver& maneuver,
                                              uint32_t element_max_count =
                                                  kVerbalPreElementMaxCount,
-                                             std::string delim = kVerbalDelim);
+                                             const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormTransitConnectionStartInstruction(Maneuver& maneuver);
@@ -352,13 +337,13 @@ class NarrativeBuilder {
   std::string FormVerbalPostTransitConnectionDestinationInstruction(
       Maneuver& maneuver,
       uint32_t element_max_count = kVerbalPreElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormVerbalPostTransitionInstruction(
       Maneuver& maneuver, bool include_street_names = false,
       uint32_t element_max_count = kVerbalPostElementMaxCount,
-      std::string delim = kVerbalDelim);
+      const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalPostTransitionTransitInstruction(Maneuver& maneuver);
 
@@ -427,7 +412,7 @@ class NarrativeBuilder {
                                  const StreetNames& street_names,
                                  bool enhance_empty_street_names = false,
                                  uint32_t max_count = 0,
-                                 std::string delim = "/",
+                                 const std::string& delim = "/",
                                  const VerbalTextFormatter* verbal_formatter =
                                      nullptr);
 
@@ -461,7 +446,7 @@ class NarrativeBuilder {
       const Maneuver& maneuver, const StreetNames& street_names,
       const std::vector<std::string>* empty_street_name_labels = nullptr,
       bool enhance_empty_street_names = false, uint32_t max_count = 0,
-      std::string delim = "/", const VerbalTextFormatter* verbal_formatter =
+      const std::string& delim = "/", const VerbalTextFormatter* verbal_formatter =
           nullptr);
 
   /**
@@ -483,7 +468,7 @@ class NarrativeBuilder {
    * @return the street names string for the specified street name list.
    */
   std::string FormStreetNames(const StreetNames& street_names,
-                              uint32_t max_count = 0, std::string delim = "/",
+                              uint32_t max_count = 0, const std::string& delim = "/",
                               const VerbalTextFormatter* verbal_formatter =
                                   nullptr);
 


### PR DESCRIPTION
…ase set

@dgearhart please have a look. i broke out sharp turns because its easier for translations sake for it to be completely apart instead of having sharp and regular and then slight by itself. also added tests for sharp. in the builder i reused one function for all of them instead of duplicating the functions at the cost of an additional switch statement.

also the by no means finshed/good/passable german language file is in here (untested). i need to get the other transit phrases you just added as well.