### PR TITLE
remove hardcoded transit narrative strings and use phrasesets

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -838,7 +838,15 @@
       "us_customary_lengths": ["<MILES> miles", "1 mile", "a half mile", "<TENTHS_OF_MILE> tenths of a mile", "1 tenth of a mile", "<FEET> feet", "less than 10 feet"],
       "empty_street_name_labels": ["walkway", "cycleway", "mountain bike trail"]
     },
-    "post_transition_transit_verbal": null,
+    "post_transition_transit_verbal": {
+      "phrases": {
+        "0": "Travel <TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>."
+      },
+      "transit_stop_count_labels": ["stop", "stops"],
+      "example_phrases": {
+        "0": ["Travel 1 stop.", "Travel 3 stops."]
+      }
+    },
     "verbal_multi_cue": {
       "phrases": {
         "0": "<CURRENT_VERBAL_CUE> Then <NEXT_VERBAL_CUE>"

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <unordered_map>
 
 #include "proto/tripdirections.pb.h"
 #include "proto/directions_options.pb.h"

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -615,9 +615,7 @@ const TransitStop& Maneuver::transit_connection_stop() const {
 void Maneuver::set_transit_connection_stop(
     const TransitStop& transit_connection_stop) {
   transit_connection_stop_ = transit_connection_stop;
-  LOG_TRACE("transit_connection_stop_.name=" + transit_connection_stop_.name);
-  LOG_TRACE("transit_connection_stop_.arrival_date_time=" + transit_connection_stop_.arrival_date_time);
-  LOG_TRACE("transit_connection_stop_.departure_date_time=" + transit_connection_stop_.departure_date_time);
+  LOG_TRACE("transit_connection_stop=" + transit_connection_stop_.ToParameterString());
 }
 
 bool Maneuver::rail() const {

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -2487,27 +2487,23 @@ std::string NarrativeBuilder::FormTransitConnectionStartInstruction(
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
-  uint8_t phrase_id = 0;
 
-  if (!maneuver.transit_connection_stop().name.empty()) {
+  std::string transit_stop = maneuver.transit_connection_stop().name;
+
+  // Determine which phrase to use
+  uint8_t phrase_id = 0;
+  if (!transit_stop.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Enter the <TRANSIT_CONNECTION_STOP> station."
-    case 1: {
-      instruction = (boost::format("Enter the %1% station.")
-          % maneuver.transit_connection_stop().name).str();
-      break;
-    }
-    // 0 "Enter station."
-    default: {
-      instruction = "Enter station.";
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_connection_start_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop);
 
   return instruction;
+
 }
 
 std::string NarrativeBuilder::FormVerbalTransitConnectionStartInstruction(
@@ -2517,27 +2513,23 @@ std::string NarrativeBuilder::FormVerbalTransitConnectionStartInstruction(
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
-  uint8_t phrase_id = 0;
 
-  if (!maneuver.transit_connection_stop().name.empty()) {
+  std::string transit_stop = maneuver.transit_connection_stop().name;
+
+  // Determine which phrase to use
+  uint8_t phrase_id = 0;
+  if (!transit_stop.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Enter the <TRANSIT_CONNECTION_STOP> station."
-    case 1: {
-      instruction = (boost::format("Enter the %1% station.")
-          % maneuver.transit_connection_stop().name).str();
-      break;
-    }
-    // 0 "Enter station."
-    default: {
-      instruction = "Enter station.";
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_connection_start_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop);
 
   return instruction;
+
 }
 
 std::string NarrativeBuilder::FormTransitConnectionTransferInstruction(

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -3227,7 +3227,7 @@ std::string NarrativeBuilder::FormVerbalPostTransitionInstruction(
 
 std::string NarrativeBuilder::FormVerbalPostTransitionTransitInstruction(
     Maneuver& maneuver) {
-  // 0 "Travel <TRANSIT_STOP_COUNT> <FormStopCountLabel>"
+  // "0": "Travel <TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>."
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -2698,7 +2698,7 @@ std::string NarrativeBuilder::FormArriveInstruction(Maneuver& maneuver) {
 
   // Replace phrase tags with values
   boost::replace_all(instruction, kTransitStopTag, transit_stop_name);
-  boost::replace_all(instruction, kTimeTag, maneuver.GetFormattedTransitDepartureTime());
+  boost::replace_all(instruction, kTimeTag, maneuver.GetFormattedTransitArrivalTime());
 
   return instruction;
 }
@@ -2721,7 +2721,7 @@ std::string NarrativeBuilder::FormVerbalArriveInstruction(Maneuver& maneuver) {
 
   // Replace phrase tags with values
   boost::replace_all(instruction, kTransitStopTag, transit_stop_name);
-  boost::replace_all(instruction, kTimeTag, maneuver.GetFormattedTransitDepartureTime());
+  boost::replace_all(instruction, kTimeTag, maneuver.GetFormattedTransitArrivalTime());
 
   return instruction;
 }

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -2599,25 +2599,20 @@ std::string NarrativeBuilder::FormTransitConnectionDestinationInstruction(
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
-  uint8_t phrase_id = 0;
 
-  if (!maneuver.transit_connection_stop().name.empty()) {
+  std::string transit_stop = maneuver.transit_connection_stop().name;
+
+  // Determine which phrase to use
+  uint8_t phrase_id = 0;
+  if (!transit_stop.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Exit the <TRANSIT_CONNECTION_STOP> station."
-    case 1: {
-      instruction = (boost::format("Exit the %1% station.")
-          % maneuver.transit_connection_stop().name).str();
-      break;
-    }
-    // 0 "Exit station."
-    default: {
-      instruction = "Exit station.";
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_connection_destination_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop);
 
   return instruction;
 
@@ -2630,25 +2625,20 @@ std::string NarrativeBuilder::FormVerbalTransitConnectionDestinationInstruction(
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
-  uint8_t phrase_id = 0;
 
-  if (!maneuver.transit_connection_stop().name.empty()) {
+  std::string transit_stop = maneuver.transit_connection_stop().name;
+
+  // Determine which phrase to use
+  uint8_t phrase_id = 0;
+  if (!transit_stop.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Exit the <TRANSIT_CONNECTION_STOP> station."
-    case 1: {
-      instruction = (boost::format("Exit the %1% station.")
-          % maneuver.transit_connection_stop().name).str();
-      break;
-    }
-    // 0 "Exit station."
-    default: {
-      instruction = "Exit station.";
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_connection_destination_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop);
 
   return instruction;
 

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -2483,7 +2483,7 @@ std::string NarrativeBuilder::FormVerbalExitFerryInstruction(
 std::string NarrativeBuilder::FormTransitConnectionStartInstruction(
     Maneuver& maneuver) {
   // "0": "Enter the station.",
-  // "1": "Enter the <TRANSIT_STOP> station."
+  // "1": "Enter the <TRANSIT_STOP> Station."
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
@@ -2513,7 +2513,7 @@ std::string NarrativeBuilder::FormTransitConnectionStartInstruction(
 std::string NarrativeBuilder::FormVerbalTransitConnectionStartInstruction(
     Maneuver& maneuver) {
   // "0": "Enter the station.",
-  // "1": "Enter the <TRANSIT_STOP> station."
+  // "1": "Enter the <TRANSIT_STOP> Station."
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
@@ -2543,7 +2543,7 @@ std::string NarrativeBuilder::FormVerbalTransitConnectionStartInstruction(
 std::string NarrativeBuilder::FormTransitConnectionTransferInstruction(
     Maneuver& maneuver) {
   // "0": "Transfer at the station.",
-  // "1": "Transfer at the <TRANSIT_STOP> station."
+  // "1": "Transfer at the <TRANSIT_STOP> Station."
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
@@ -2573,7 +2573,7 @@ std::string NarrativeBuilder::FormTransitConnectionTransferInstruction(
 std::string NarrativeBuilder::FormVerbalTransitConnectionTransferInstruction(
     Maneuver& maneuver) {
   // "0": "Transfer at the station.",
-  // "1": "Transfer at the <TRANSIT_STOP> station."
+  // "1": "Transfer at the <TRANSIT_STOP> Station."
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -2539,25 +2539,19 @@ std::string NarrativeBuilder::FormTransitConnectionTransferInstruction(
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
-  uint8_t phrase_id = 0;
+  std::string transit_stop = maneuver.transit_connection_stop().name;
 
-  if (!maneuver.transit_connection_stop().name.empty()) {
+  // Determine which phrase to use
+  uint8_t phrase_id = 0;
+  if (!transit_stop.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Transfer at the <TRANSIT_CONNECTION_STOP> station."
-    case 1: {
-      instruction = (boost::format("Transfer at the %1% station.")
-          % maneuver.transit_connection_stop().name).str();
-      break;
-    }
-    // 0 "Transfer at station."
-    default: {
-      instruction = "Transfer at station.";
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_connection_transfer_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop);
 
   return instruction;
 }
@@ -2569,25 +2563,19 @@ std::string NarrativeBuilder::FormVerbalTransitConnectionTransferInstruction(
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
-  uint8_t phrase_id = 0;
+  std::string transit_stop = maneuver.transit_connection_stop().name;
 
-  if (!maneuver.transit_connection_stop().name.empty()) {
+  // Determine which phrase to use
+  uint8_t phrase_id = 0;
+  if (!transit_stop.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Transfer at the <TRANSIT_CONNECTION_STOP> station."
-    case 1: {
-      instruction = (boost::format("Transfer at the %1% station.")
-          % maneuver.transit_connection_stop().name).str();
-      break;
-    }
-    // 0 "Transfer at station."
-    default: {
-      instruction = "Transfer at station.";
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_connection_transfer_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop);
 
   return instruction;
 }
@@ -2657,22 +2645,12 @@ std::string NarrativeBuilder::FormDepartInstruction(Maneuver& maneuver) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Depart: <GetFormattedTransitDepartureTime> from <FIRST_TRANSIT_STOP>.
-    case 1: {
-      instruction =
-          (boost::format("Depart: %1% from %2%.")
-              % maneuver.GetFormattedTransitDepartureTime() % transit_stop_name)
-              .str();
-      break;
-    }
-    // 0 "Depart: <GetFormattedTransitDepartureTime>.
-    default: {
-      instruction = (boost::format("Depart: %1%.")
-          % maneuver.GetFormattedTransitDepartureTime()).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.depart_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop_name);
+  boost::replace_all(instruction, kTimeTag, maneuver.GetFormattedTransitDepartureTime());
 
   return instruction;
 }
@@ -2690,22 +2668,12 @@ std::string NarrativeBuilder::FormVerbalDepartInstruction(Maneuver& maneuver) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Depart at <GetFormattedTransitDepartureTime> from <FIRST_TRANSIT_STOP>.
-    case 1: {
-      instruction =
-          (boost::format("Depart at %1% from %2%.")
-              % maneuver.GetFormattedTransitDepartureTime() % transit_stop_name)
-              .str();
-      break;
-    }
-    // 0 "Depart at <GetFormattedTransitDepartureTime>.
-    default: {
-      instruction = (boost::format("Depart at %1%.")
-          % maneuver.GetFormattedTransitDepartureTime()).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.depart_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop_name);
+  boost::replace_all(instruction, kTimeTag, maneuver.GetFormattedTransitDepartureTime());
 
   return instruction;
 }
@@ -2723,22 +2691,12 @@ std::string NarrativeBuilder::FormArriveInstruction(Maneuver& maneuver) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Arrive: <GetFormattedTransitArrivalTime> at <LAST_TRANSIT_STOP>.
-    case 1: {
-      instruction =
-          (boost::format("Arrive: %1% at %2%.")
-              % maneuver.GetFormattedTransitArrivalTime() % transit_stop_name)
-              .str();
-      break;
-    }
-    // 0 "Arrive: <GetFormattedTransitArrivalTime>.
-    default: {
-      instruction = (boost::format("Arrive: %1%.")
-          % maneuver.GetFormattedTransitArrivalTime()).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.arrive_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop_name);
+  boost::replace_all(instruction, kTimeTag, maneuver.GetFormattedTransitDepartureTime());
 
   return instruction;
 }
@@ -2756,22 +2714,12 @@ std::string NarrativeBuilder::FormVerbalArriveInstruction(Maneuver& maneuver) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Arrive at <GetFormattedTransitArrivalTime> at <LAST_TRANSIT_STOP>.
-    case 1: {
-      instruction =
-          (boost::format("Arrive at %1% at %2%.")
-              % maneuver.GetFormattedTransitArrivalTime() % transit_stop_name)
-              .str();
-      break;
-    }
-    // 0 "Arrive at <GetFormattedTransitArrivalTime>.
-    default: {
-      instruction = (boost::format("Arrive at %1%.")
-          % maneuver.GetFormattedTransitArrivalTime()).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.arrive_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopTag, transit_stop_name);
+  boost::replace_all(instruction, kTimeTag, maneuver.GetFormattedTransitDepartureTime());
 
   return instruction;
 }
@@ -2785,28 +2733,21 @@ std::string NarrativeBuilder::FormTransitInstruction(
   instruction.reserve(kInstructionInitialCapacity);
   uint8_t phrase_id = 0;
   std::string transit_headsign = maneuver.transit_info().headsign;
+  auto stop_count = maneuver.GetTransitStopCount();
+  auto stop_count_label = dictionary_.transit_subset.transit_stop_count_labels.at(stop_count != 1);
 
   if (!transit_headsign.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <FormStopCountLabel>)"
-    case 1: {
-      instruction = (boost::format("Take the %1% toward %2%. (%3% %4%)")
-          % FormTransitName(maneuver) % transit_headsign
-          % maneuver.GetTransitStopCount()
-          % FormStopCountLabel(maneuver.GetTransitStopCount())).str();
-      break;
-    }
-    // 0 "Take the <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <FormStopCountLabel>)"
-    default: {
-      instruction = (boost::format("Take the %1%. (%2% %3%)")
-          % FormTransitName(maneuver) % maneuver.GetTransitStopCount()
-          % FormStopCountLabel(maneuver.GetTransitStopCount())).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
+  boost::replace_all(instruction, kTransitStopCountTag, std::to_string(stop_count)); //TODO: locale specific numerals
+  boost::replace_all(instruction, kTransitStopCountLabelTag, stop_count_label);
 
   return instruction;
 }
@@ -2824,20 +2765,12 @@ std::string NarrativeBuilder::FormVerbalTransitInstruction(Maneuver& maneuver) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>."
-    case 1: {
-      instruction = (boost::format("Take the %1% toward %2%.")
-          % FormTransitName(maneuver) % transit_headsign).str();
-      break;
-    }
-    // 0 "Take the <TRANSIT_NAME>."
-    default: {
-      instruction = (boost::format("Take the %1%.") % FormTransitName(maneuver))
-          .str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
 
   return instruction;
 }
@@ -2851,28 +2784,21 @@ std::string NarrativeBuilder::FormTransitRemainOnInstruction(
   instruction.reserve(kInstructionInitialCapacity);
   uint8_t phrase_id = 0;
   std::string transit_headsign = maneuver.transit_info().headsign;
+  auto stop_count = maneuver.GetTransitStopCount();
+  auto stop_count_label = dictionary_.transit_remain_on_subset.transit_stop_count_labels.at(stop_count != 1);
 
   if (!transit_headsign.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 Remain on the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <FormStopCountLabel>)"
-    case 1: {
-      instruction = (boost::format("Remain on the %1% toward %2%. (%3% %4%)")
-          % FormTransitName(maneuver) % transit_headsign
-          % maneuver.GetTransitStopCount()
-          % FormStopCountLabel(maneuver.GetTransitStopCount())).str();
-      break;
-    }
-    // 0 Remain on the <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <FormStopCountLabel>)"
-    default: {
-      instruction = (boost::format("Remain on the %1%. (%2% %3%)")
-          % FormTransitName(maneuver) % maneuver.GetTransitStopCount()
-          % FormStopCountLabel(maneuver.GetTransitStopCount())).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_remain_on_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
+  boost::replace_all(instruction, kTransitStopCountTag, std::to_string(stop_count)); //TODO: locale specific numerals
+  boost::replace_all(instruction, kTransitStopCountLabelTag, stop_count_label);
 
   return instruction;
 
@@ -2892,23 +2818,14 @@ std::string NarrativeBuilder::FormVerbalTransitRemainOnInstruction(
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 Remain on the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>."
-    case 1: {
-      instruction = (boost::format("Remain on the %1% toward %2%.")
-          % FormTransitName(maneuver) % transit_headsign).str();
-      break;
-    }
-    // 0 Remain on the <TRANSIT_NAME>."
-    default: {
-      instruction = (boost::format("Remain on the %1%.")
-          % FormTransitName(maneuver)).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_remain_on_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
 
   return instruction;
-
 }
 
 std::string NarrativeBuilder::FormTransitTransferInstruction(
@@ -2920,28 +2837,21 @@ std::string NarrativeBuilder::FormTransitTransferInstruction(
   instruction.reserve(kInstructionInitialCapacity);
   uint8_t phrase_id = 0;
   std::string transit_headsign = maneuver.transit_info().headsign;
+  auto stop_count = maneuver.GetTransitStopCount();
+  auto stop_count_label = dictionary_.transit_transfer_subset.transit_stop_count_labels.at(stop_count != 1);
 
   if (!transit_headsign.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Transfer to take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <FormStopCountLabel>)"
-    case 1: {
-      instruction = (boost::format("Transfer to take the %1% toward %2%. (%3% %4%)")
-          % FormTransitName(maneuver) % transit_headsign
-          % maneuver.GetTransitStopCount()
-          % FormStopCountLabel(maneuver.GetTransitStopCount())).str();
-      break;
-    }
-    // 0 "Transfer to take the <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <FormStopCountLabel>)"
-    default: {
-      instruction = (boost::format("Transfer to take the %1%. (%2% %3%)")
-          % FormTransitName(maneuver) % maneuver.GetTransitStopCount()
-          % FormStopCountLabel(maneuver.GetTransitStopCount())).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_transfer_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
+  boost::replace_all(instruction, kTransitStopCountTag, std::to_string(stop_count)); //TODO: locale specific numerals
+  boost::replace_all(instruction, kTransitStopCountLabelTag, stop_count_label);
 
   return instruction;
 
@@ -2961,21 +2871,12 @@ std::string NarrativeBuilder::FormVerbalTransitTransferInstruction(
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Transfer to take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>."
-    case 1: {
-      instruction = (boost::format(
-          "Transfer to take the %1% toward %2%.")
-          % FormTransitName(maneuver) % transit_headsign).str();
-      break;
-    }
-    // 0 "Transfer to take the <TRANSIT_NAME>."
-    default: {
-      instruction = (boost::format("Transfer to take the %1%.")
-          % FormTransitName(maneuver)).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.transit_transfer_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
 
   return instruction;
 
@@ -2987,43 +2888,40 @@ std::string NarrativeBuilder::FormPostTransitConnectionDestinationInstruction(
   // "1": "Head <CARDINAL_DIRECTION> on <STREET_NAMES>.",
   // "2": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
 
-  // Assign the street names and the begin street names
-  std::string street_names = FormOldStreetNames(maneuver, maneuver.street_names(),
-                                             true);
-  std::string begin_street_names = FormOldStreetNames(
-      maneuver, maneuver.begin_street_names());
-
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
-  uint8_t phrase_id = 0;
-  std::string cardinal_direction = FormCardinalDirection(
-        maneuver.begin_cardinal_direction());
 
-  if (!begin_street_names.empty() && !street_names.empty()) {
+  // Set cardinal_direction value
+  std::string cardinal_direction = dictionary_.post_transit_connection_destination_subset
+      .cardinal_directions.at(maneuver.begin_cardinal_direction());
+
+  // Assign the street names
+  std::string street_names = FormStreetNames(
+      maneuver, maneuver.street_names(),
+      &dictionary_.post_transit_connection_destination_subset.empty_street_name_labels, true);
+
+  // Assign the begin street names
+  std::string begin_street_names = FormStreetNames(
+      maneuver, maneuver.begin_street_names(),
+      &dictionary_.post_transit_connection_destination_subset.empty_street_name_labels);
+
+  // Determine which phrase to use
+  uint8_t phrase_id = 0;
+  if (!begin_street_names.empty()) {
     phrase_id = 2;
   } else if (!street_names.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Head <FormCardinalDirection> on <STREET_NAMES>."
-    case 1: {
-      instruction = (boost::format("Head %1% on %2%.") % cardinal_direction
-          % street_names).str();
-      break;
-    }
-    // 2 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
-    case 2: {
-      instruction = (boost::format("Head %1% on %2%. Continue on %3%.")
-          % cardinal_direction % begin_street_names % street_names).str();
-      break;
-    }
-    // 0 "Head <FormCardinalDirection>."
-    default: {
-      instruction = (boost::format("Head %1%.") % cardinal_direction).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.post_transit_connection_destination_subset.
+      phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kCardinalDirectionTag, cardinal_direction);
+  boost::replace_all(instruction, kStreetNamesTag, street_names);
+  boost::replace_all(instruction, kBeginStreetNamesTag, begin_street_names);
+
 
   return instruction;
 
@@ -3033,47 +2931,43 @@ std::string NarrativeBuilder::FormVerbalPostTransitConnectionDestinationInstruct
     Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // 0 "Head <FormCardinalDirection>."
   // 1 "Head <FormCardinalDirection> on <STREET_NAMES>."
-  // 2 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
-
-  // Assign the street names and the begin street names
-  std::string street_names = FormOldStreetNames(maneuver, maneuver.street_names(),
-                                             true, element_max_count, delim,
-                                             maneuver.verbal_formatter());
-  std::string begin_street_names = FormOldStreetNames(
-      maneuver, maneuver.begin_street_names(), false, element_max_count, delim,
-      maneuver.verbal_formatter());
+  // 2 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>."
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
-  uint8_t phrase_id = 0;
-  std::string cardinal_direction = FormCardinalDirection(
-        maneuver.begin_cardinal_direction());
 
-  if (!begin_street_names.empty() && !street_names.empty()) {
+  // Set cardinal_direction value
+  std::string cardinal_direction = dictionary_.post_transit_connection_destination_verbal_subset
+      .cardinal_directions.at(maneuver.begin_cardinal_direction());
+
+  // Assign the street names
+  std::string street_names = FormStreetNames(
+      maneuver, maneuver.street_names(),
+      &dictionary_.post_transit_connection_destination_verbal_subset.empty_street_name_labels, true,
+      element_max_count, delim, maneuver.verbal_formatter());
+
+  // Assign the begin street names
+  std::string begin_street_names = FormStreetNames(
+      maneuver, maneuver.begin_street_names(),
+      &dictionary_.post_transit_connection_destination_verbal_subset.empty_street_name_labels, false,
+      element_max_count, delim, maneuver.verbal_formatter());
+
+  // Determine which phrase to use
+  uint8_t phrase_id = 0;
+  if (!begin_street_names.empty()) {
     phrase_id = 2;
   } else if (!street_names.empty()) {
     phrase_id = 1;
   }
 
-  switch (phrase_id) {
-    // 1 "Head <FormCardinalDirection> on <STREET_NAMES>."
-    case 1: {
-      instruction = (boost::format("Head %1% on %2%.") % cardinal_direction
-          % street_names).str();
-      break;
-    }
-    // 2 "Head <FormCardinalDirection> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
-    case 2: {
-      instruction = (boost::format("Head %1% on %2%. Continue on %3%.")
-          % cardinal_direction % begin_street_names % street_names).str();
-      break;
-    }
-    // 0 "Head <FormCardinalDirection>."
-    default: {
-      instruction = (boost::format("Head %1%.") % cardinal_direction).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.post_transit_connection_destination_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kCardinalDirectionTag, cardinal_direction);
+  boost::replace_all(instruction, kStreetNamesTag, street_names);
+  boost::replace_all(instruction, kBeginStreetNamesTag, begin_street_names);
+
 
   return instruction;
 
@@ -3121,16 +3015,16 @@ std::string NarrativeBuilder::FormVerbalPostTransitionTransitInstruction(
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
   uint8_t phrase_id = 0;
+  auto stop_count = maneuver.GetTransitStopCount();
+  auto stop_count_label = dictionary_.post_transition_transit_verbal_subset.
+      transit_stop_count_labels.at(stop_count != 1);
 
-  switch (phrase_id) {
-    // 0 "Travel <TRANSIT_STOP_COUNT> <FormStopCountLabel>"
-    default: {
-      instruction = (boost::format("Travel %1% %2%.")
-          % maneuver.GetTransitStopCount()
-          % FormStopCountLabel(maneuver.GetTransitStopCount())).str();
-      break;
-    }
-  }
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.post_transition_transit_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kTransitStopCountTag, std::to_string(stop_count)); //TODO: locale specific numerals
+  boost::replace_all(instruction, kTransitStopCountLabelTag, stop_count_label);
 
   return instruction;
 }
@@ -3199,7 +3093,7 @@ std::string NarrativeBuilder::FormMetricLength(
       (kilometer_tenths == kilometer_tenths_floor) ?
           (boost::format("%.0f") % kilometer_tenths_floor).str() :
           (boost::format("%.1f") % kilometer_tenths).str());
-  boost::replace_all(length_string, kMetersTag, std::to_string(meters));
+  boost::replace_all(length_string, kMetersTag, std::to_string(meters));  //TODO: locale specific numerals
 
 
   return length_string;
@@ -3259,8 +3153,8 @@ std::string NarrativeBuilder::FormUsCustomaryLength(
       (mile_tenths == mile_tenths_floor) ?
           (boost::format("%.0f") % mile_tenths_floor).str() :
           (boost::format("%.1f") % mile_tenths).str());
-  boost::replace_all(length_string, kTenthsOfMilesTag, std::to_string(tenths_of_mile));
-  boost::replace_all(length_string, kFeetTag, std::to_string(feet));
+  boost::replace_all(length_string, kTenthsOfMilesTag, std::to_string(tenths_of_mile));  //TODO: locale specific numerals
+  boost::replace_all(length_string, kFeetTag, std::to_string(feet));  //TODO: locale specific numerals
 
   return length_string;
 }

--- a/src/odin/transitstop.cc
+++ b/src/odin/transitstop.cc
@@ -1,45 +1,68 @@
+#include <unordered_map>
+
+#include "proto/tripdirections.pb.h"
+#include "proto/directions_options.pb.h"
 #include "odin/transitstop.h"
 #include "odin/util.h"
 
 namespace valhalla {
 namespace odin {
 
-TransitStop::TransitStop(TripPath_TransitStopInfo_Type type,
+const std::unordered_map<int, TripDirections_TransitStop_Type> translate_transit_stop_type {
+  { static_cast<int>(TripPath_TransitStopInfo_Type_kStop), TripDirections_TransitStop_Type_kStop },
+  { static_cast<int>(TripPath_TransitStopInfo_Type_kStation), TripDirections_TransitStop_Type_kStation },
+};
+
+TransitStop::TransitStop(TripDirections_TransitStop_Type type,
                          std::string onestop_id, std::string name,
                          std::string arrival_date_time,
                          std::string departure_date_time,
                          bool is_parent_stop,
                          bool assumed_schedule)
-    : onestop_id(onestop_id),
+    : type(type),
+      onestop_id(onestop_id),
       name(name),
       arrival_date_time(arrival_date_time),
       departure_date_time(departure_date_time),
       is_parent_stop(is_parent_stop),
       assumed_schedule(assumed_schedule) {
-  set_type(type);
 }
 
-void TransitStop::set_type(TripPath_TransitStopInfo_Type in_type) {
-  switch (in_type) {
-    case TripPath_TransitStopInfo_Type_kStation: {
-      type = TripDirections_TransitStop_Type_kStation;
-      break;
-    }
-    default: {
-      type = TripDirections_TransitStop_Type_kStop;
-    }
-  }
+TransitStop::TransitStop(TripPath_TransitStopInfo_Type type,
+                         std::string onestop_id, std::string name,
+                         std::string arrival_date_time,
+                         std::string departure_date_time, bool is_parent_stop,
+                         bool assumed_schedule)
+    : TransitStop(translate_transit_stop_type.find(type)->second, onestop_id,
+                  name, arrival_date_time, departure_date_time, is_parent_stop,
+                  assumed_schedule) {
 }
 
-// TODO: do we need?
 std::string TransitStop::ToParameterString() const {
   const std::string delim = ", ";
   std::string str;
   str += "{ ";
-  //str += GetQuotedString(text_);
+
+  str += "TripDirections_TransitStop_Type_";
+  str += TripDirections_TransitStop_Type_descriptor()->FindValueByNumber(type)->name();
 
   str += delim;
-  //str += GetQuotedString(std::to_string(consecutive_count_));
+  str += GetQuotedString(onestop_id);
+
+  str += delim;
+  str += GetQuotedString(name);
+
+  str += delim;
+  str += GetQuotedString(arrival_date_time);
+
+  str += delim;
+  str += GetQuotedString(departure_date_time);
+
+  str += delim;
+  str += std::to_string(is_parent_stop);
+
+  str += delim;
+  str += std::to_string(assumed_schedule);
 
   str += " }";
 

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -3,6 +3,7 @@
 #include <valhalla/baldr/verbal_text_formatter_factory.h>
 
 #include "proto/trippath.pb.h"
+#include "proto/tripdirections.pb.h"
 #include "odin/maneuver.h"
 #include "odin/sign.h"
 #include "odin/signs.h"
@@ -1545,6 +1546,40 @@ void PopulateExitFerryManeuverList_2(std::list<Maneuver>& maneuvers,
                    TripDirections_Maneuver_CardinalDirection_kNorthEast, 31, 62,
                    23, 25, 71, 75, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
                    { }, 1, 0, 0, 0, 0, 0, "", "", "", 0, 0, 0, 0, 5, 0);
+}
+
+void PopulateTransitConnectionStartManeuverList_0(
+    std::list<Maneuver>& maneuvers, const std::string& country_code,
+    const std::string& state_code) {
+  maneuvers.emplace_back();
+  Maneuver& maneuver = maneuvers.back();
+  PopulateManeuver(maneuver, country_code, state_code,
+                   TripDirections_Maneuver_Type_kTransitConnectionStart, {
+                       "Broadway" },
+                   { }, { }, "", 0.036000, 28, 0,
+                   Maneuver::RelativeDirection::kKeepStraight,
+                   TripDirections_Maneuver_CardinalDirection_kSouthWest, 213,
+                   212, 2, 3, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { }, 0, 0, 0, 0, 1, 0, "", "", "", 0, 0, 0, 0, 25, 0);
+}
+
+void PopulateTransitConnectionStartManeuverList_1(
+    std::list<Maneuver>& maneuvers, const std::string& country_code,
+    const std::string& state_code) {
+  maneuvers.emplace_back();
+  Maneuver& maneuver = maneuvers.back();
+  PopulateManeuver(maneuver, country_code, state_code,
+                   TripDirections_Maneuver_Type_kTransitConnectionStart, {
+                       "Broadway" },
+                   { }, { }, "", 0.036000, 28, 0,
+                   Maneuver::RelativeDirection::kKeepStraight,
+                   TripDirections_Maneuver_CardinalDirection_kSouthWest, 213,
+                   212, 2, 3, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { }, 0, 0, 0, 0, 1, 0, "", "", "", 0, 0, 0, 0, 25, 0);
+  maneuver.set_transit_connection_stop(
+      TransitStop(TripDirections_TransitStop_Type_kStation,
+                  "s-dr5rsq8pqg-8st~nyu<r21n", "8 St - NYU", "",
+                  "2016-03-29T08:02", 0, 0));
 }
 
 void PopulateVerbalMultiCueManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -4168,9 +4203,9 @@ void TestBuildExitFerry_2_miles_en_US() {
 
 ///////////////////////////////////////////////////////////////////////////////
 // FormTransitConnectionStartInstruction
-// "0": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
-// "0": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>."
-// "0": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>."
+// "0": "Enter the station.",
+// No verbal alert
+// "0": "Enter the station.",
 void TestBuildTransitConnectionStart_0_miles_en_US() {
   std::string country_code = "US";
   std::string state_code = "PA";
@@ -4182,16 +4217,56 @@ void TestBuildTransitConnectionStart_0_miles_en_US() {
 
   // Configure maneuvers
   std::list<Maneuver> maneuvers;
-//  PopulateTransitConnectionStartManeuverList_0(maneuvers, country_code, state_code);
+  PopulateTransitConnectionStartManeuverList_0(maneuvers, country_code, state_code);
 
   // Configure expected maneuvers based on directions options
   std::list<Maneuver> expected_maneuvers;
-//  PopulateTransitConnectionStartManeuverList_0(expected_maneuvers, country_code, state_code);
+  PopulateTransitConnectionStartManeuverList_0(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(expected_maneuvers,
-                                  "Head northeast on Cape May-Lewes Ferry Entrance/US 9. Continue on US 9.",
-                                  "Head northeast on Cape May-Lewes Ferry Entrance.",
-                                  "Head northeast on Cape May-Lewes Ferry Entrance, U.S. 9.",
-                                  "Continue on U.S. 9 for 300 feet.");
+                                  "Enter station.",
+                                  "",
+                                  "Enter station.",
+                                  "Continue for 100 feet.");
+//TODO: update when code is updated
+//                                  "Enter the station.",
+//                                  "",
+//                                  "Enter the station.",
+//                                  "Continue for 100 feet.");
+
+  TryBuild(directions_options, maneuvers, expected_maneuvers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FormTransitConnectionStartInstruction
+// "1": "Enter the station.",
+// No verbal alert
+// "1": "Enter the station.",
+void TestBuildTransitConnectionStart_1_miles_en_US() {
+  std::string country_code = "US";
+  std::string state_code = "PA";
+
+  // Configure directions options
+  DirectionsOptions directions_options;
+  directions_options.set_units(DirectionsOptions_Units_kMiles);
+  directions_options.set_language("en-US");
+
+  // Configure maneuvers
+  std::list<Maneuver> maneuvers;
+  PopulateTransitConnectionStartManeuverList_1(maneuvers, country_code, state_code);
+
+  // Configure expected maneuvers based on directions options
+  std::list<Maneuver> expected_maneuvers;
+  PopulateTransitConnectionStartManeuverList_1(expected_maneuvers, country_code, state_code);
+  SetExpectedManeuverInstructions(expected_maneuvers,
+                                  "Enter the 8 St - NYU station.",
+                                  "",
+                                  "Enter the 8 St - NYU station.",
+                                  "Continue for 100 feet.");
+//TODO: update when code is updated
+//                                  "Enter the 8 St - NYU Station.",
+//                                  "",
+//                                  "Enter the 8 St - NYU Station.",
+//                                  "Continue for 100 feet.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
 }
@@ -5526,7 +5601,10 @@ int main() {
   suite.test(TEST_CASE(TestBuildExitFerry_2_miles_en_US));
 
   // BuildTransitConnectionStart_0_miles_en_US
-//  suite.test(TEST_CASE(TestBuildTransitConnectionStart_0_miles_en_US));
+  suite.test(TEST_CASE(TestBuildTransitConnectionStart_0_miles_en_US));
+
+  // BuildTransitConnectionStart_1_miles_en_US
+  suite.test(TEST_CASE(TestBuildTransitConnectionStart_1_miles_en_US));
 
   // BuildVerbalMultiCue_0_miles_en_US
   suite.test(TEST_CASE(TestBuildVerbalMultiCue_0_miles_en_US));

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -1582,6 +1582,40 @@ void PopulateTransitConnectionStartManeuverList_1(
                   "2016-03-29T08:02", 0, 0));
 }
 
+void PopulateTransitConnectionDestinationManeuverList_0(
+    std::list<Maneuver>& maneuvers, const std::string& country_code,
+    const std::string& state_code) {
+  maneuvers.emplace_back();
+  Maneuver& maneuver = maneuvers.back();
+  PopulateManeuver(maneuver, country_code, state_code,
+                   TripDirections_Maneuver_Type_kTransitConnectionDestination, {
+                       "Broadway" },
+                   { }, { }, "", 0.036000, 25, 196,
+                   Maneuver::RelativeDirection::KReverse,
+                   TripDirections_Maneuver_CardinalDirection_kNorthEast, 32, 33,
+                   11, 12, 16, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { }, 0, 0, 0, 0, 1, 0, "", "", "", 0, 0, 0, 0, 25, 0);
+}
+
+void PopulateTransitConnectionDestinationManeuverList_1(
+    std::list<Maneuver>& maneuvers, const std::string& country_code,
+    const std::string& state_code) {
+  maneuvers.emplace_back();
+  Maneuver& maneuver = maneuvers.back();
+  PopulateManeuver(maneuver, country_code, state_code,
+                   TripDirections_Maneuver_Type_kTransitConnectionDestination, {
+                       "Broadway" },
+                   { }, { }, "", 0.036000, 25, 196,
+                   Maneuver::RelativeDirection::KReverse,
+                   TripDirections_Maneuver_CardinalDirection_kNorthEast, 32, 33,
+                   11, 12, 16, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { },
+                   { }, 0, 0, 0, 0, 1, 0, "", "", "", 0, 0, 0, 0, 25, 0);
+  maneuver.set_transit_connection_stop(
+      TransitStop(TripDirections_TransitStop_Type_kStation,
+                  "s-dr5rsq8pqg-8st~nyu<r21s", "8 St - NYU", "2016-03-29T08:19",
+                  "", 0, 0));
+}
+
 void PopulateVerbalMultiCueManeuverList_0(std::list<Maneuver>& maneuvers,
                                           const std::string& country_code,
                                           const std::string& state_code) {
@@ -4262,6 +4296,66 @@ void TestBuildTransitConnectionStart_1_miles_en_US() {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// FormTransitConnectionDestinationInstruction
+// "0": "Exit the station.",
+// No verbal alert
+// "0": "Exit the station.",
+void TestBuildTransitConnectionDestination_0_miles_en_US() {
+  std::string country_code = "US";
+  std::string state_code = "PA";
+
+  // Configure directions options
+  DirectionsOptions directions_options;
+  directions_options.set_units(DirectionsOptions_Units_kMiles);
+  directions_options.set_language("en-US");
+
+  // Configure maneuvers
+  std::list<Maneuver> maneuvers;
+  PopulateTransitConnectionDestinationManeuverList_0(maneuvers, country_code, state_code);
+
+  // Configure expected maneuvers based on directions options
+  std::list<Maneuver> expected_maneuvers;
+  PopulateTransitConnectionDestinationManeuverList_0(expected_maneuvers, country_code, state_code);
+  SetExpectedManeuverInstructions(expected_maneuvers,
+                                  "Exit the station.",
+                                  "",
+                                  "Exit the station.",
+                                  "Continue for 100 feet.");
+
+  TryBuild(directions_options, maneuvers, expected_maneuvers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FormTransitConnectionDestinationInstruction
+// "1": "Exit the <TRANSIT_STOP> Station."
+// No verbal alert
+// "1": "Exit the <TRANSIT_STOP> Station."
+void TestBuildTransitConnectionDestination_1_miles_en_US() {
+  std::string country_code = "US";
+  std::string state_code = "PA";
+
+  // Configure directions options
+  DirectionsOptions directions_options;
+  directions_options.set_units(DirectionsOptions_Units_kMiles);
+  directions_options.set_language("en-US");
+
+  // Configure maneuvers
+  std::list<Maneuver> maneuvers;
+  PopulateTransitConnectionDestinationManeuverList_1(maneuvers, country_code, state_code);
+
+  // Configure expected maneuvers based on directions options
+  std::list<Maneuver> expected_maneuvers;
+  PopulateTransitConnectionDestinationManeuverList_1(expected_maneuvers, country_code, state_code);
+  SetExpectedManeuverInstructions(expected_maneuvers,
+                                  "Exit the 8 St - NYU Station.",
+                                  "",
+                                  "Exit the 8 St - NYU Station.",
+                                  "Continue for 100 feet.");
+
+  TryBuild(directions_options, maneuvers, expected_maneuvers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // FormVerbalMultiCue
 // 0 "<CURRENT_VERBAL_CUE> Then <NEXT_VERBAL_CUE>"
 void TestBuildVerbalMultiCue_0_miles_en_US() {
@@ -5595,6 +5689,12 @@ int main() {
 
   // BuildTransitConnectionStart_1_miles_en_US
   suite.test(TEST_CASE(TestBuildTransitConnectionStart_1_miles_en_US));
+
+  // BuildTransitConnectionDestination_0_miles_en_US
+  suite.test(TEST_CASE(TestBuildTransitConnectionDestination_0_miles_en_US));
+
+  // BuildTransitConnectionDestination_1_miles_en_US
+  suite.test(TEST_CASE(TestBuildTransitConnectionDestination_1_miles_en_US));
 
   // BuildVerbalMultiCue_0_miles_en_US
   suite.test(TEST_CASE(TestBuildVerbalMultiCue_0_miles_en_US));

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -3973,6 +3973,36 @@ void TestBuildExitFerry_2_miles_en_US() {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// FormTransitConnectionStartInstruction
+// "0": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>."
+// "0": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>."
+// "0": "Head <CARDINAL_DIRECTION> on <BEGIN_STREET_NAMES>."
+void TestBuildTransitConnectionStart_0_miles_en_US() {
+  std::string country_code = "US";
+  std::string state_code = "PA";
+
+  // Configure directions options
+  DirectionsOptions directions_options;
+  directions_options.set_units(DirectionsOptions_Units_kMiles);
+  directions_options.set_language("en-US");
+
+  // Configure maneuvers
+  std::list<Maneuver> maneuvers;
+//  PopulateTransitConnectionStartManeuverList_0(maneuvers, country_code, state_code);
+
+  // Configure expected maneuvers based on directions options
+  std::list<Maneuver> expected_maneuvers;
+//  PopulateTransitConnectionStartManeuverList_0(expected_maneuvers, country_code, state_code);
+  SetExpectedManeuverInstructions(expected_maneuvers,
+                                  "Head northeast on Cape May-Lewes Ferry Entrance/US 9. Continue on US 9.",
+                                  "Head northeast on Cape May-Lewes Ferry Entrance.",
+                                  "Head northeast on Cape May-Lewes Ferry Entrance, U.S. 9.",
+                                  "Continue on U.S. 9 for 300 feet.");
+
+  TryBuild(directions_options, maneuvers, expected_maneuvers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // FormVerbalMultiCue
 // 0 "<CURRENT_VERBAL_CUE> Then <NEXT_VERBAL_CUE>"
 void TestBuildVerbalMultiCue_0_miles_en_US() {
@@ -5288,6 +5318,9 @@ int main() {
 
   // BuildExitFerry_2_miles_en_US
   suite.test(TEST_CASE(TestBuildExitFerry_2_miles_en_US));
+
+  // BuildTransitConnectionStart_0_miles_en_US
+//  suite.test(TEST_CASE(TestBuildTransitConnectionStart_0_miles_en_US));
 
   // BuildVerbalMultiCue_0_miles_en_US
   suite.test(TEST_CASE(TestBuildVerbalMultiCue_0_miles_en_US));

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -4223,24 +4223,19 @@ void TestBuildTransitConnectionStart_0_miles_en_US() {
   std::list<Maneuver> expected_maneuvers;
   PopulateTransitConnectionStartManeuverList_0(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(expected_maneuvers,
-                                  "Enter station.",
+                                  "Enter the station.",
                                   "",
-                                  "Enter station.",
+                                  "Enter the station.",
                                   "Continue for 100 feet.");
-//TODO: update when code is updated
-//                                  "Enter the station.",
-//                                  "",
-//                                  "Enter the station.",
-//                                  "Continue for 100 feet.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // FormTransitConnectionStartInstruction
-// "1": "Enter the station.",
+// "1": "Enter the <TRANSIT_STOP> Station."
 // No verbal alert
-// "1": "Enter the station.",
+// "1": "Enter the <TRANSIT_STOP> Station."
 void TestBuildTransitConnectionStart_1_miles_en_US() {
   std::string country_code = "US";
   std::string state_code = "PA";
@@ -4258,15 +4253,10 @@ void TestBuildTransitConnectionStart_1_miles_en_US() {
   std::list<Maneuver> expected_maneuvers;
   PopulateTransitConnectionStartManeuverList_1(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(expected_maneuvers,
-                                  "Enter the 8 St - NYU station.",
+                                  "Enter the 8 St - NYU Station.",
                                   "",
-                                  "Enter the 8 St - NYU station.",
+                                  "Enter the 8 St - NYU Station.",
                                   "Continue for 100 feet.");
-//TODO: update when code is updated
-//                                  "Enter the 8 St - NYU Station.",
-//                                  "",
-//                                  "Enter the 8 St - NYU Station.",
-//                                  "Continue for 100 feet.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
 }

--- a/valhalla/odin/narrative_dictionary.h
+++ b/valhalla/odin/narrative_dictionary.h
@@ -124,6 +124,11 @@ constexpr auto kTowardSignTag = "<TOWARD_SIGN>";
 constexpr auto kNameSignTag = "<NAME_SIGN>";
 constexpr auto kFerryLabelTag = "<FERRY_LABEL>";
 constexpr auto kTransitStopTag = "<TRANSIT_STOP>";
+constexpr auto kTimeTag = "<TIME>";
+constexpr auto kTransitNameTag = "<TRANSIT_NAME>";
+constexpr auto kTransitHeadSignTag = "<TRANSIT_HEADSIGN>";
+constexpr auto kTransitStopCountTag = "<TRANSIT_STOP_COUNT>";
+constexpr auto kTransitStopCountLabelTag = "<TRANSIT_STOP_COUNT_LABEL>";
 
 }
 

--- a/valhalla/odin/transitstop.h
+++ b/valhalla/odin/transitstop.h
@@ -11,15 +11,17 @@ namespace odin {
 
 struct TransitStop {
 
+  TransitStop(TripDirections_TransitStop_Type type, std::string onestop_id,
+              std::string name, std::string arrival_date_time,
+              std::string departure_date_time, bool is_parent_stop,
+              bool assumed_schedule);
+
   TransitStop(TripPath_TransitStopInfo_Type type, std::string onestop_id,
               std::string name, std::string arrival_date_time,
               std::string departure_date_time, bool is_parent_stop,
               bool assumed_schedule);
 
-  // TODO: do we need?
   std::string ToParameterString() const;
-
-  void set_type(TripPath_TransitStopInfo_Type in_type);
 
   TripDirections_TransitStop_Type type;
   std::string onestop_id;


### PR DESCRIPTION
this should have all of the transit stuff using the dictionary/phrases now instead of hardcoded strings. obviously its not tested until i can merge @dgearhart 's tests, so as soon as he pushes/generates those i'll pull them and fix anything ive messed up.