### PR TITLE
validate language files against en-US

### DIFF
--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -619,7 +619,7 @@
       "phrases": {
         "0": "Die Fähre nehmen.",
         "1": "Die <STREET_NAMES> nehmen.",
-        "2": "Die <STREET_NAMES> <FERRY_LABEL> nehmen."
+        "2": "Die <FERRY_LABEL> <STREET_NAMES> nehmen."
       },
       "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
       "ferry_label": "Fähre",
@@ -633,7 +633,7 @@
       "phrases": {
         "0": "Die Fähre nehmen.",
         "1": "Die <STREET_NAMES> nehmen.",
-        "2": "Die <STREET_NAMES> <FERRY_LABEL> nehmen."
+        "2": "Die <FERRY_LABEL> <STREET_NAMES> nehmen."
       },
       "empty_street_name_labels": ["Fußweg", "Radweg", "Mountainbike Strecke"],
       "ferry_label": "Ferry",

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -302,7 +302,7 @@
         "0": "Geradeaus über die Rampe fahren.",
         "1": "Auf <BRANCH_SIGN> geradeaus über die Rampe fahren.",
         "2": "Geradeaus über die Rampe fahren Richtung <TOWARD_SIGN>.",
-        "4": "Geradeaus über die Rampe <NAME_SIGN> fahren."
+        "3": "Geradeaus über die Rampe <NAME_SIGN> fahren."
       },
       "example_phrases": {
         "0": ["Stay straight to take the ramp."],

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -138,8 +138,6 @@ std::string get_localized_time(const std::string& date_time, const std::string& 
       output_facet = new boost::posix_time::time_facet("%l:%M %p");
       ss.imbue(std::locale(std::locale::classic(), output_facet));
       ss << pt;
-      std::cout << ss.str() << std::endl;
-
     }
   } catch (std::exception& e){}
   std::string result = ss.str();

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -183,5 +183,9 @@ const locales_singleton_t& get_locales() {
   return locales;
 }
 
+const std::unordered_map<std::string, std::string>& get_locales_json() {
+  return locales_json;
+}
+
 }
 }

--- a/valhalla/odin/util.h
+++ b/valhalla/odin/util.h
@@ -47,12 +47,19 @@ std::string get_localized_date(const std::string& date_time,
                                const std::string& locale);
 
 /**
- * Returns a list of locales mapped to NarrativeDictionary's containing parsed narrative information
+ * Returns locale strings mapped to NarrativeDictionaries containing parsed narrative information
  *
- * @return the map of locale to ptree of parse narrative json/yml
+ * @return the map of locales to NarrativeDictionaries
  */
 using locales_singleton_t = std::unordered_map<std::string, NarrativeDictionary>;
 const locales_singleton_t& get_locales();
+
+/**
+ * Returns locale strings mapped to json strings defining the dictionaries
+ *
+ * @return the map of locales to json strings
+ */
+const std::unordered_map<std::string, std::string>& get_locales_json();
 
 }
 }


### PR DESCRIPTION
this works really nice in that it tells both what and where the problem is. i tested missing phrases, missing replacements, missing tags, wrong names of phrases (wrong keys), wrong items under the instruction, and if the posix locale is supported. only thing i dont like is that its a unit test. id rather it be run in make and fail compilation instead but this is probably too strict anyway.

oh also it found a bug in german language file

@dgearhart please have a look