### PR TITLE
Added empty_transit_name_labels with some examples

### DIFF
--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -792,10 +792,11 @@
         "0": "Nastupte na <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Nastupte na <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "transit_stop_count_labels": ["zastávka", "zastávek"],
       "example_phrases": {
-        "0": ["Nastupte na New Haven. (1 zastávka)"],
-        "1": ["Nastupte na F směr JAMAICA - 179 ST. (10 zastávek)"]
+        "0": ["Nastupte na New Haven. (1 zastávka)", "Take the metro. (2 stops)", "Take the bus. (12 stops)"],
+        "1": ["Nastupte na F směr JAMAICA - 179 ST. (10 zastávek)", "Take the ferry toward Staten Island. (1 stop)"]
       }
     },
     "transit_verbal": {
@@ -803,6 +804,7 @@
         "0": "Nastupte na <TRANSIT_NAME>.",
         "1": "Nastupte na <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>."
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "example_phrases": {
         "0": ["Nastupte na New Haven."],
         "1": ["Nastupte na F směr JAMAICA - 179 ST."]
@@ -813,9 +815,10 @@
         "0": "Zůstaňte v <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Zůstaňte v <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "transit_stop_count_labels": ["zastávka", "zastávek"],
       "example_phrases": {
-        "0": ["Zůstaňte v New Haven. (1 zastávka)"],
+        "0": ["Zůstaňte v New Haven. (1 zastávka)", "Remain on the train. (3 stops)"],
         "1": ["Zůstaňte v F směr JAMAICA - 179 ST. (10 zastávek)"]
       }
     },
@@ -824,6 +827,7 @@
         "0": "Zůstaňte v <TRANSIT_NAME>.",
         "1": "Zůstaňte v <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>."
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "example_phrases": {
         "0": ["Zůstaňte v New Haven."],
         "1": ["Zůstaňte v F směr JAMAICA - 179 ST."]
@@ -834,9 +838,10 @@
         "0": "Přestupte na <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Přestupte na <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "transit_stop_count_labels": ["zastávka", "zastávek"],
       "example_phrases": {
-        "0": ["Přestupte na New Haven. (1 zastávka)"],
+        "0": ["Přestupte na New Haven. (1 zastávka)", "Transfer to take the tram. (4 stops)"],
         "1": ["Přestupte na F směr JAMAICA - 179 ST. (10 zastávek)"]
       }
     },
@@ -845,6 +850,7 @@
         "0": "Přestupte na <TRANSIT_NAME>.",
         "1": "Přestupte na <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>."
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "example_phrases": {
         "0": ["Přestupte na New Haven."],
         "1": ["Přestupte na F směr JAMAICA - 179 ST."]

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -792,10 +792,11 @@
         "0": "Mit der Linie <TRANSIT_NAME> fahren. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> fahren. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
       "example_phrases": {
-        "0": ["Take the New Haven. (1 stop)"],
-        "1": ["Take the F toward JAMAICA - 179 ST. (10 stops)"]
+        "0": ["Take the New Haven. (1 stop)", "Take the metro. (2 stops)", "Take the bus. (12 stops)"],
+        "1": ["Take the F toward JAMAICA - 179 ST. (10 stops)", "Take the ferry toward Staten Island. (1 stop)"]
       }
     },
     "transit_verbal": {
@@ -803,6 +804,7 @@
         "0": "Mit der Linie <TRANSIT_NAME> fahren.",
         "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> fahren."
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "example_phrases": {
         "0": ["Take the New Haven."],
         "1": ["Take the F toward JAMAICA - 179 ST."]
@@ -813,9 +815,10 @@
         "0": "Mit der Linie <TRANSIT_NAME> weiter. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> weiter. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
       "example_phrases": {
-        "0": ["Remain on the New Haven. (1 stop)"],
+        "0": ["Remain on the New Haven. (1 stop)", "Remain on the train. (3 stops)"],
         "1": ["Remain on the F toward JAMAICA - 179 ST. (10 stops)"]
       }
     },
@@ -824,6 +827,7 @@
         "0": "Mit der Linie <TRANSIT_NAME> weiter.",
         "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> weiter."
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "example_phrases": {
         "0": ["Remain on the New Haven."],
         "1": ["Remain on the F toward JAMAICA - 179 ST."]
@@ -834,9 +838,10 @@
         "0": "Zur Linie <TRANSIT_NAME> umsteigen. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Zur Linie <TRANSIT_NAME> Richtugn <TRANSIT_HEADSIGN> umsteigen. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
       "example_phrases": {
-        "0": ["Transfer to take the New Haven. (1 stop)"],
+        "0": ["Transfer to take the New Haven. (1 stop)", "Transfer to take the tram. (4 stops)"],
         "1": ["Transfer to take the F toward JAMAICA - 179 ST. (10 stops)"]
       }
     },
@@ -845,6 +850,7 @@
         "0": "Zur Linie <TRANSIT_NAME> umsteigen.",
         "1": "Zur Linie <TRANSIT_NAME> Richtugn <TRANSIT_HEADSIGN> umsteigen."
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "example_phrases": {
         "0": ["Transfer to take the New Haven."],
         "1": ["Transfer to take the F toward JAMAICA - 179 ST."]

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -792,10 +792,11 @@
         "0": "Take the <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "transit_stop_count_labels": ["stop", "stops"],
       "example_phrases": {
-        "0": ["Take the New Haven. (1 stop)"],
-        "1": ["Take the F toward JAMAICA - 179 ST. (10 stops)"]
+        "0": ["Take the New Haven. (1 stop)", "Take the metro. (2 stops)", "Take the bus. (12 stops)"],
+        "1": ["Take the F toward JAMAICA - 179 ST. (10 stops)", "Take the ferry toward Staten Island. (1 stop)"]
       }
     },
     "transit_verbal": {
@@ -803,6 +804,7 @@
         "0": "Take the <TRANSIT_NAME>.",
         "1": "Take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>."
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "example_phrases": {
         "0": ["Take the New Haven."],
         "1": ["Take the F toward JAMAICA - 179 ST."]
@@ -813,9 +815,10 @@
         "0": "Remain on the <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Remain on the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "transit_stop_count_labels": ["stop", "stops"],
       "example_phrases": {
-        "0": ["Remain on the New Haven. (1 stop)"],
+        "0": ["Remain on the New Haven. (1 stop)", "Remain on the train. (3 stops)"],
         "1": ["Remain on the F toward JAMAICA - 179 ST. (10 stops)"]
       }
     },
@@ -824,6 +827,7 @@
         "0": "Remain on the <TRANSIT_NAME>.",
         "1": "Remain on the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>."
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "example_phrases": {
         "0": ["Remain on the New Haven."],
         "1": ["Remain on the F toward JAMAICA - 179 ST."]
@@ -834,9 +838,10 @@
         "0": "Transfer to take the <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Transfer to take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "transit_stop_count_labels": ["stop", "stops"],
       "example_phrases": {
-        "0": ["Transfer to take the New Haven. (1 stop)"],
+        "0": ["Transfer to take the New Haven. (1 stop)", "Transfer to take the tram. (4 stops)"],
         "1": ["Transfer to take the F toward JAMAICA - 179 ST. (10 stops)"]
       }
     },
@@ -845,6 +850,7 @@
         "0": "Transfer to take the <TRANSIT_NAME>.",
         "1": "Transfer to take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>."
       },
+      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
       "example_phrases": {
         "0": ["Transfer to take the New Haven."],
         "1": ["Transfer to take the F toward JAMAICA - 179 ST."]

--- a/src/odin/narrative_dictionary.cc
+++ b/src/odin/narrative_dictionary.cc
@@ -294,6 +294,7 @@ void NarrativeDictionary::Load(
   // Populate post_transition_verbal_subset
   Load(post_transition_verbal_subset, narrative_pt.get_child(kPostTransitionVerbalKey));
 
+  /////////////////////////////////////////////////////////////////////////////
   LOG_TRACE("Populate post_transition_transit_verbal_subset...");
   // Populate post_transition_transit_verbal_subset
   Load(post_transition_transit_verbal_subset, narrative_pt.get_child(kPostTransitTransitionVerbalKey));
@@ -464,6 +465,45 @@ void NarrativeDictionary::Load(
 }
 
 void NarrativeDictionary::Load(
+    TransitConnectionSubset& transit_connection_handle,
+    const boost::property_tree::ptree& transit_connection_subset_pt) {
+
+  // Populate phrases
+  Load(static_cast<PhraseSet&>(transit_connection_handle), transit_connection_subset_pt);
+
+  // Populate station_label
+  transit_connection_handle.station_label = transit_connection_subset_pt.get<std::string>(
+      kStationLabelKey);
+
+}
+
+void NarrativeDictionary::Load(
+    TransitSubset& transit_handle,
+    const boost::property_tree::ptree& transit_subset_pt) {
+
+  // Populate phrases
+  Load(static_cast<PhraseSet&>(transit_handle), transit_subset_pt);
+
+  // Populate transit_count_labels
+  transit_handle.empty_transit_name_labels = as_vector<std::string>(
+      transit_subset_pt, kEmptyTransitNameLabelsKey);
+
+}
+
+void NarrativeDictionary::Load(
+    TransitStopSubset& transit_stop_handle,
+    const boost::property_tree::ptree& transit_stop_subset_pt) {
+
+  // Populate phrases
+  Load(static_cast<TransitSubset&>(transit_stop_handle), transit_stop_subset_pt);
+
+  // Populate transit_stop_count_labels
+  transit_stop_handle.transit_stop_count_labels = as_vector<std::string>(
+      transit_stop_subset_pt, kTransitStopCountLabelsKey);
+
+}
+
+void NarrativeDictionary::Load(
     PostTransitionVerbalSubset& post_transition_verbal_handle,
     const boost::property_tree::ptree& post_transition_verbal_subset_pt) {
 
@@ -485,28 +525,17 @@ void NarrativeDictionary::Load(
 }
 
 void NarrativeDictionary::Load(
-    TransitConnectionSubset& transit_connection_handle,
-    const boost::property_tree::ptree& transit_connection_subset_pt) {
+    PostTransitionTransitVerbalSubset& post_transition_transit_verbal_handle,
+    const boost::property_tree::ptree& post_transition_transit_verbal_subset_pt) {
 
   // Populate phrases
-  Load(static_cast<PhraseSet&>(transit_connection_handle), transit_connection_subset_pt);
-
-  // Populate station_label
-  transit_connection_handle.station_label = transit_connection_subset_pt.get<std::string>(
-      kStationLabelKey);
-
-}
-
-void NarrativeDictionary::Load(
-    TransitStopSubset& transit_stop_handle,
-    const boost::property_tree::ptree& transit_stop_subset_pt) {
-
-  // Populate phrases
-  Load(static_cast<PhraseSet&>(transit_stop_handle), transit_stop_subset_pt);
+  Load(static_cast<PhraseSet&>(post_transition_transit_verbal_handle),
+       post_transition_transit_verbal_subset_pt);
 
   // Populate transit_stop_count_labels
-  transit_stop_handle.transit_stop_count_labels = as_vector<std::string>(
-      transit_stop_subset_pt, kTransitStopCountLabelsKey);
+  post_transition_transit_verbal_handle.transit_stop_count_labels = as_vector<
+      std::string>(post_transition_transit_verbal_subset_pt,
+                   kTransitStopCountLabelsKey);
 
 }
 

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -2776,7 +2776,11 @@ std::string NarrativeBuilder::FormTransitInstruction(
   instruction = dictionary_.transit_subset.phrases.at(std::to_string(phrase_id));
 
   // Replace phrase tags with values
-  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(
+      instruction,
+      kTransitNameTag,
+      FormTransitName(maneuver,
+                      dictionary_.transit_subset.empty_transit_name_labels));
   boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
   boost::replace_all(instruction, kTransitStopCountTag, std::to_string(stop_count)); //TODO: locale specific numerals
   boost::replace_all(instruction, kTransitStopCountLabelTag, stop_count_label);
@@ -2801,7 +2805,11 @@ std::string NarrativeBuilder::FormVerbalTransitInstruction(Maneuver& maneuver) {
   instruction = dictionary_.transit_verbal_subset.phrases.at(std::to_string(phrase_id));
 
   // Replace phrase tags with values
-  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(
+      instruction,
+      kTransitNameTag,
+      FormTransitName(maneuver,
+                      dictionary_.transit_verbal_subset.empty_transit_name_labels));
   boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
 
   return instruction;
@@ -2827,7 +2835,12 @@ std::string NarrativeBuilder::FormTransitRemainOnInstruction(
   instruction = dictionary_.transit_remain_on_subset.phrases.at(std::to_string(phrase_id));
 
   // Replace phrase tags with values
-  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(
+      instruction,
+      kTransitNameTag,
+      FormTransitName(
+          maneuver,
+          dictionary_.transit_remain_on_subset.empty_transit_name_labels));
   boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
   boost::replace_all(instruction, kTransitStopCountTag, std::to_string(stop_count)); //TODO: locale specific numerals
   boost::replace_all(instruction, kTransitStopCountLabelTag, stop_count_label);
@@ -2854,7 +2867,12 @@ std::string NarrativeBuilder::FormVerbalTransitRemainOnInstruction(
   instruction = dictionary_.transit_remain_on_verbal_subset.phrases.at(std::to_string(phrase_id));
 
   // Replace phrase tags with values
-  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(
+      instruction,
+      kTransitNameTag,
+      FormTransitName(
+          maneuver,
+          dictionary_.transit_remain_on_verbal_subset.empty_transit_name_labels));
   boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
 
   return instruction;
@@ -2880,7 +2898,12 @@ std::string NarrativeBuilder::FormTransitTransferInstruction(
   instruction = dictionary_.transit_transfer_subset.phrases.at(std::to_string(phrase_id));
 
   // Replace phrase tags with values
-  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(
+      instruction,
+      kTransitNameTag,
+      FormTransitName(
+          maneuver,
+          dictionary_.transit_transfer_subset.empty_transit_name_labels));  //TODO: need generic names in dictionary
   boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
   boost::replace_all(instruction, kTransitStopCountTag, std::to_string(stop_count)); //TODO: locale specific numerals
   boost::replace_all(instruction, kTransitStopCountLabelTag, stop_count_label);
@@ -2907,7 +2930,12 @@ std::string NarrativeBuilder::FormVerbalTransitTransferInstruction(
   instruction = dictionary_.transit_transfer_verbal_subset.phrases.at(std::to_string(phrase_id));
 
   // Replace phrase tags with values
-  boost::replace_all(instruction, kTransitNameTag, FormTransitName(maneuver)); //TODO: need generic names in dictionary
+  boost::replace_all(
+      instruction,
+      kTransitNameTag,
+      FormTransitName(
+          maneuver,
+          dictionary_.transit_transfer_verbal_subset.empty_transit_name_labels));
   boost::replace_all(instruction, kTransitHeadSignTag, transit_headsign);
 
   return instruction;
@@ -3238,16 +3266,15 @@ std::string NarrativeBuilder::FormRelativeThreeDirection(
   }
 }
 
-// TODO: handle bus/train
-std::string NarrativeBuilder::FormTransitName(Maneuver& maneuver) {
+std::string NarrativeBuilder::FormTransitName(
+    const Maneuver& maneuver,
+    const std::vector<std::string>& empty_transit_name_labels) {
   if (!maneuver.transit_info().short_name.empty()) {
     return maneuver.transit_info().short_name;
   } else if (!maneuver.transit_info().long_name.empty()) {
     return (maneuver.transit_info().long_name);
-  } else if (maneuver.bus()) {
-    return "bus";
   }
-  return "train";
+  return empty_transit_name_labels.at(maneuver.transit_type());
 }
 
 // NOTE: Tried to use 'contains' instead of 'ends_with'

--- a/test/narrative_dictionary.cc
+++ b/test/narrative_dictionary.cc
@@ -22,6 +22,7 @@ const std::vector<std::string> kExpectedRelativeThreeDirections = { "left", "str
 const std::vector<std::string> kExpectedOrdinalValues = { "1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th" };
 const std::string kExpectedFerryLabel = "Ferry";
 const std::string kExpectedStationLabel = "Station";
+const std::vector<std::string> kExpectedEmptyTransitNameLabels = { "tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular" };
 const std::vector<std::string> kExpectedTransitStopCountLabels = { "stop", "stops" };
 
 // Expected phrases
@@ -1279,6 +1280,10 @@ void test_en_US_transit() {
   const auto& phrase_1 = dictionary.transit_subset.phrases.at("1");
   validate(phrase_1, "Take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)");
 
+  // empty_transit_name_labels
+  const auto& empty_transit_name_labels = dictionary.transit_subset.empty_transit_name_labels;
+  validate(empty_transit_name_labels, kExpectedEmptyTransitNameLabels);
+
   // transit_stop_count_labels
   const auto& transit_stop_count_labels = dictionary.transit_subset.transit_stop_count_labels;
   validate(transit_stop_count_labels, kExpectedTransitStopCountLabels);
@@ -1294,6 +1299,10 @@ void test_en_US_transit_verbal() {
   const auto& phrase_1 = dictionary.transit_verbal_subset.phrases.at("1");
   validate(phrase_1, "Take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>.");
 
+  // empty_transit_name_labels
+  const auto& empty_transit_name_labels = dictionary.transit_subset.empty_transit_name_labels;
+  validate(empty_transit_name_labels, kExpectedEmptyTransitNameLabels);
+
 }
 
 void test_en_US_transit_remain_on() {
@@ -1304,6 +1313,10 @@ void test_en_US_transit_remain_on() {
 
   const auto& phrase_1 = dictionary.transit_remain_on_subset.phrases.at("1");
   validate(phrase_1, "Remain on the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)");
+
+  // empty_transit_name_labels
+  const auto& empty_transit_name_labels = dictionary.transit_subset.empty_transit_name_labels;
+  validate(empty_transit_name_labels, kExpectedEmptyTransitNameLabels);
 
   // transit_stop_count_labels
   const auto& transit_stop_count_labels = dictionary.transit_remain_on_subset.transit_stop_count_labels;
@@ -1320,6 +1333,10 @@ void test_en_US_transit_remain_on_verbal() {
   const auto& phrase_1 = dictionary.transit_remain_on_verbal_subset.phrases.at("1");
   validate(phrase_1, "Remain on the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>.");
 
+  // empty_transit_name_labels
+  const auto& empty_transit_name_labels = dictionary.transit_subset.empty_transit_name_labels;
+  validate(empty_transit_name_labels, kExpectedEmptyTransitNameLabels);
+
 }
 
 void test_en_US_transit_transfer() {
@@ -1330,6 +1347,10 @@ void test_en_US_transit_transfer() {
 
   const auto& phrase_1 = dictionary.transit_transfer_subset.phrases.at("1");
   validate(phrase_1, "Transfer to take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)");
+
+  // empty_transit_name_labels
+  const auto& empty_transit_name_labels = dictionary.transit_subset.empty_transit_name_labels;
+  validate(empty_transit_name_labels, kExpectedEmptyTransitNameLabels);
 
   // transit_stop_count_labels
   const auto& transit_stop_count_labels = dictionary.transit_transfer_subset.transit_stop_count_labels;
@@ -1345,6 +1366,10 @@ void test_en_US_transit_transfer_verbal() {
 
   const auto& phrase_1 = dictionary.transit_transfer_verbal_subset.phrases.at("1");
   validate(phrase_1, "Transfer to take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>.");
+
+  // empty_transit_name_labels
+  const auto& empty_transit_name_labels = dictionary.transit_subset.empty_transit_name_labels;
+  validate(empty_transit_name_labels, kExpectedEmptyTransitNameLabels);
 
 }
 

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -1842,7 +1842,7 @@ void PopulateTransitConnectionDestinationManeuverList_2(
                   "", 0, 0));
 }
 
-void PopulateTransitManeuverList_0_no_name(std::list<Maneuver>& maneuvers,
+void PopulateTransitManeuverList_0_train(std::list<Maneuver>& maneuvers,
                                            const std::string& country_code,
                                            const std::string& state_code) {
   maneuvers.emplace_back();
@@ -1893,6 +1893,8 @@ void PopulateTransitManeuverList_0_no_name(std::list<Maneuver>& maneuvers,
           TransitStop(TripDirections_TransitStop_Type_kStation,
                       "s-dr5rsq8pqg-8st~nyu<r21n", "8 St - NYU", "",
                       "2016-03-29T08:02", 0, 1)));
+
+  maneuver.set_transit_type(TripPath_TransitType_kRail);
 }
 
 void PopulateTransitManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -1946,6 +1948,71 @@ void PopulateTransitManeuverList_0(std::list<Maneuver>& maneuvers,
           TransitStop(TripDirections_TransitStop_Type_kStation,
                       "s-dr5rsq8pqg-8st~nyu<r21n", "8 St - NYU", "",
                       "2016-03-29T08:02", 0, 1)));
+}
+
+void PopulateTransitManeuverList_1_cable_car(std::list<Maneuver>& maneuvers,
+                                             const std::string& country_code,
+                                             const std::string& state_code) {
+  maneuvers.emplace_back();
+  Maneuver& maneuver = maneuvers.back();
+  PopulateManeuver(maneuver, country_code, state_code,
+                   TripDirections_Maneuver_Type_kTransit, { }, { }, { }, "",
+                   0.826000, 502, 289, Maneuver::RelativeDirection::kLeft,
+                   TripDirections_Maneuver_CardinalDirection_kSouth, 171, 171,
+                   2, 9, 3, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { }, { }, { },
+                   0, 1, 0, 0, 0, 0, "", "", "", 0, 0, 0, 0, 595, 0);
+
+  PopulateTransitInfo(maneuver.mutable_transit_info(), "r-9q8zn-powell~hyde", 0,
+                      26285, "", "", "Powell & Market", 16777215, 0,
+                      "", "o-9q8y-sfmta",
+                      "San Francisco Municipal Transportation Agency",
+                      "http://www.sfmta.com/");
+
+  // Insert the transit stops in reverse order (end to begin of line)
+  maneuver.InsertTransitStop(
+      std::move(
+          TransitStop(TripDirections_TransitStop_Type_kStation,
+                      "s-9q8zn2c3gg-hydest~vallejost", "Hyde St & Vallejo St",
+                      "2016-05-17T08:06", "", 0, 1)));
+  maneuver.InsertTransitStop(
+      std::move(
+          TransitStop(TripDirections_TransitStop_Type_kStation,
+                      "s-9q8zn2cpr9-hydest~greenst", "Hyde St & Green St",
+                      "2016-05-17T08:06", "2016-05-17T08:06", 0, 1)));
+  maneuver.InsertTransitStop(
+      std::move(
+          TransitStop(TripDirections_TransitStop_Type_kStation,
+                      "s-9q8zn31h5q-hydest~unionst", "Hyde St & Union St",
+                      "2016-05-17T08:06", "2016-05-17T08:06", 0, 1)));
+  maneuver.InsertTransitStop(
+      std::move(
+          TransitStop(TripDirections_TransitStop_Type_kStation,
+                      "s-9q8zn32fnv-hydest~filbertst", "Hyde St & Filbert St",
+                      "2016-05-17T08:05", "2016-05-17T08:05", 0, 1)));
+  maneuver.InsertTransitStop(
+      std::move(
+          TransitStop(TripDirections_TransitStop_Type_kStation,
+                      "s-9q8zn32yg5-hydest~greenwichst",
+                      "Hyde St & Greenwich St", "2016-05-17T08:05",
+                      "2016-05-17T08:05", 0, 1)));
+  maneuver.InsertTransitStop(
+      std::move(
+          TransitStop(TripDirections_TransitStop_Type_kStation,
+                      "s-9q8zn38ez1-hydest~lombardst", "Hyde St & Lombard St",
+                      "2016-05-17T08:04", "2016-05-17T08:04", 0, 1)));
+  maneuver.InsertTransitStop(
+      std::move(
+          TransitStop(TripDirections_TransitStop_Type_kStation,
+                      "s-9q8zn3b9cv-hydest~chestnutst", "Hyde St & Chestnut St",
+                      "2016-05-17T08:04", "2016-05-17T08:04", 0, 1)));
+  maneuver.InsertTransitStop(
+      std::move(
+          TransitStop(TripDirections_TransitStop_Type_kStation,
+                      "s-9q8zn60kc1-hydest~bayst", "Hyde St & Bay St", "",
+                      "2016-05-17T08:03", 0, 1)));
+
+  maneuver.set_transit_type(TripPath_TransitType_kCableCar);
+
 }
 
 void PopulateTransitManeuverList_1(std::list<Maneuver>& maneuvers,
@@ -5385,7 +5452,7 @@ void TestBuildTransitConnectionDestination_2_miles_en_US() {
 // "0": "Take the <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
 // No verbal alert
 // "0": "Take the <TRANSIT_NAME>.",
-void TestBuildTransit_0_no_name_miles_en_US() {
+void TestBuildTransit_0_train_miles_en_US() {
   std::string country_code = "US";
   std::string state_code = "PA";
 
@@ -5396,11 +5463,11 @@ void TestBuildTransit_0_no_name_miles_en_US() {
 
   // Configure maneuvers
   std::list<Maneuver> maneuvers;
-  PopulateTransitManeuverList_0_no_name(maneuvers, country_code, state_code);
+  PopulateTransitManeuverList_0_train(maneuvers, country_code, state_code);
 
   // Configure expected maneuvers based on directions options
   std::list<Maneuver> expected_maneuvers;
-  PopulateTransitManeuverList_0_no_name(expected_maneuvers, country_code,
+  PopulateTransitManeuverList_0_train(expected_maneuvers, country_code,
                                         state_code);
   SetExpectedManeuverInstructions(expected_maneuvers, "Take the train. (4 stops)",
                                   "", "Take the train.", "Travel 4 stops.",
@@ -5442,6 +5509,41 @@ void TestBuildTransit_0_miles_en_US() {
                                   "Depart at 8:02 AM from 8 St - NYU.",
                                   "Arrive: 8:08 AM at 34 St - Herald Sq.",
                                   "Arrive at 8:08 AM at 34 St - Herald Sq.");
+
+  TryBuild(directions_options, maneuvers, expected_maneuvers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// FormTransitInstruction
+// "1": "Take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
+// No verbal alert
+// "1": "Take the <TRANSIT_NAME> toward <TRANSIT_HEADSIGN>."
+void TestBuildTransit_1_cable_car_miles_en_US() {
+  std::string country_code = "US";
+  std::string state_code = "PA";
+
+  // Configure directions options
+  DirectionsOptions directions_options;
+  directions_options.set_units(DirectionsOptions_Units_kMiles);
+  directions_options.set_language("en-US");
+
+  // Configure maneuvers
+  std::list<Maneuver> maneuvers;
+  PopulateTransitManeuverList_1_cable_car(maneuvers, country_code, state_code);
+
+  // Configure expected maneuvers based on directions options
+  std::list<Maneuver> expected_maneuvers;
+  PopulateTransitManeuverList_1_cable_car(expected_maneuvers, country_code,
+                                          state_code);
+  SetExpectedManeuverInstructions(
+      expected_maneuvers,
+      "Take the cable car toward Powell & Market. (7 stops)",
+      "",
+      "Take the cable car toward Powell & Market.", "Travel 7 stops.",
+      "Depart: 8:03 AM from Hyde St & Bay St.",
+      "Depart at 8:03 AM from Hyde St & Bay St.",
+      "Arrive: 8:06 AM at Hyde St & Vallejo St.",
+      "Arrive at 8:06 AM at Hyde St & Vallejo St.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
 }
@@ -7141,10 +7243,13 @@ int main() {
   suite.test(TEST_CASE(TestBuildTransitConnectionDestination_2_miles_en_US));
 
   // BuildTransit_0_no_name_miles_en_US
-  suite.test(TEST_CASE(TestBuildTransit_0_no_name_miles_en_US));
+  suite.test(TEST_CASE(TestBuildTransit_0_train_miles_en_US));
 
   // BuildTransit_0_miles_en_US
   suite.test(TEST_CASE(TestBuildTransit_0_miles_en_US));
+
+  // BuildTransit_1_miles_en_US
+  suite.test(TEST_CASE(TestBuildTransit_1_cable_car_miles_en_US));
 
   // BuildTransit_1_miles_en_US
   suite.test(TEST_CASE(TestBuildTransit_1_miles_en_US));

--- a/valhalla/odin/narrative_dictionary.h
+++ b/valhalla/odin/narrative_dictionary.h
@@ -83,6 +83,7 @@ constexpr auto kMetricLengthsKey = "metric_lengths";
 constexpr auto kUsCustomaryLengthsKey = "us_customary_lengths";
 constexpr auto kFerryLabelKey = "ferry_label";
 constexpr auto kStationLabelKey = "station_label";
+constexpr auto kEmptyTransitNameLabelsKey = "empty_transit_name_labels";
 constexpr auto kTransitStopCountLabelsKey = "transit_stop_count_labels";
 
 // Empty street names label indexes
@@ -186,12 +187,6 @@ struct EnterFerrySubset : PhraseSet {
   std::string ferry_label;
 };
 
-struct PostTransitionVerbalSubset : PhraseSet {
-  std::vector<std::string> metric_lengths;
-  std::vector<std::string> us_customary_lengths;
-  std::vector<std::string> empty_street_name_labels;
-};
-
 struct EnterRoundaboutSubset : PhraseSet {
   std::vector<std::string> ordinal_values;
 };
@@ -200,7 +195,21 @@ struct TransitConnectionSubset : PhraseSet {
   std::string station_label;
 };
 
-struct TransitStopSubset : PhraseSet {
+struct TransitSubset : PhraseSet {
+  std::vector<std::string> empty_transit_name_labels;
+};
+
+struct TransitStopSubset : TransitSubset {
+  std::vector<std::string> transit_stop_count_labels;
+};
+
+struct PostTransitionVerbalSubset : PhraseSet {
+  std::vector<std::string> metric_lengths;
+  std::vector<std::string> us_customary_lengths;
+  std::vector<std::string> empty_street_name_labels;
+};
+
+struct PostTransitionTransitVerbalSubset : PhraseSet {
   std::vector<std::string> transit_stop_count_labels;
 };
 
@@ -310,15 +319,15 @@ class NarrativeDictionary {
 
   // Transit
   TransitStopSubset transit_subset;
-  PhraseSet transit_verbal_subset;
+  TransitSubset transit_verbal_subset;
 
   // TransitRemainOn
   TransitStopSubset transit_remain_on_subset;
-  PhraseSet transit_remain_on_verbal_subset;
+  TransitSubset transit_remain_on_verbal_subset;
 
   // TransitTransfer
   TransitStopSubset transit_transfer_subset;
-  PhraseSet transit_transfer_verbal_subset;
+  TransitSubset transit_transfer_verbal_subset;
 
   // PostTransitConnectionDestination
   StartSubset post_transit_connection_destination_subset;
@@ -326,7 +335,9 @@ class NarrativeDictionary {
 
   // Post transition verbal
   PostTransitionVerbalSubset post_transition_verbal_subset;
-  TransitStopSubset post_transition_transit_verbal_subset;
+
+  // Post transition transit verbal
+  PostTransitionTransitVerbalSubset post_transition_transit_verbal_subset;
 
   // Verbal miulti-cue
   PhraseSet verbal_multi_cue_subset;
@@ -454,6 +465,36 @@ class NarrativeDictionary {
             const boost::property_tree::ptree& enter_ferry_subset_pt);
 
   /**
+    * Loads the specified 'transit_connection' instruction subset with the localized
+    * narrative instructions contained in the specified property tree.
+    *
+    * @param  transit_connection_handle  The 'transit_connection' structure to populate.
+    * @param  transit_connection_subset_pt  The 'transit_connection' property tree.
+    */
+  void Load(TransitConnectionSubset& transit_connection_handle,
+            const boost::property_tree::ptree& transit_connection_subset_pt);
+
+  /**
+    * Loads the specified 'transit' instruction subset with the localized
+    * narrative instructions contained in the specified property tree.
+    *
+    * @param  transit_handle  The 'transit' structure to populate.
+    * @param  transit_subset_pt  The 'transit' property tree.
+    */
+  void Load(TransitSubset& transit_handle,
+            const boost::property_tree::ptree& transit_subset_pt);
+
+  /**
+    * Loads the specified 'transit_stop' instruction subset with the localized
+    * narrative instructions contained in the specified property tree.
+    *
+    * @param  transit_stop_handle  The 'transit_stop' structure to populate.
+    * @param  transit_stop_subset_pt  The 'transit_stop' property tree.
+    */
+  void Load(TransitStopSubset& transit_stop_handle,
+            const boost::property_tree::ptree& transit_stop_subset_pt);
+
+  /**
     * Loads the specified 'post transition verbal' instruction subset with the
     * localized narrative instructions contained in the specified property tree.
     *
@@ -466,24 +507,17 @@ class NarrativeDictionary {
             const boost::property_tree::ptree& post_transition_verbal_subset_pt);
 
   /**
-    * Loads the specified 'transit_connection' instruction subset with the localized
-    * narrative instructions contained in the specified property tree.
-    *
-    * @param  transit_connection_handle  The 'transit_connection' structure to populate.
-    * @param  transit_connection_subset_pt  The 'transit_connection' property tree.
-    */
-  void Load(TransitConnectionSubset& transit_connection_handle,
-            const boost::property_tree::ptree& transit_connection_subset_pt);
-
-  /**
-    * Loads the specified 'transit_stop' instruction subset with the localized
-    * narrative instructions contained in the specified property tree.
-    *
-    * @param  transit_stop_handle  The 'transit_stop' structure to populate.
-    * @param  transit_stop_subset_pt  The 'transit_stop' property tree.
-    */
-  void Load(TransitStopSubset& transit_stop_handle,
-            const boost::property_tree::ptree& transit_stop_subset_pt);
+   * Loads the specified 'post transition_transit verbal' instruction subset with the
+   * localized narrative instructions contained in the specified property tree.
+   *
+   * @param  post_transition_transit_verbal_handle  The 'post transition_transit verbal'
+   *                                                structure to populate.
+   * @param  post_transition_transit_verbal_subset_pt  The 'post transition_transit verbal'
+   *                                                   property tree.
+   */
+  void Load(
+      PostTransitionTransitVerbalSubset& post_transition_transit_verbal_handle,
+      const boost::property_tree::ptree& post_transition_transit_verbal_subset_pt);
 
 };
 

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -390,7 +390,20 @@ class NarrativeBuilder {
       const std::vector<std::string>& relative_directions);
 
   /////////////////////////////////////////////////////////////////////////////
-  std::string FormTransitName(Maneuver& maneuver);
+  /**
+   * Returns the transit name in this precedence - depending on which one exists:
+   *    1) Short name
+   * or 2) Long name
+   * or 3) Generic name based on transit travel type
+   *
+   * @param maneuver The maneuver with the transit names to process.
+   * @param empty_transit_name_labels A list of empty transit name labels.
+   *
+   * @return the transit name.
+   */
+  std::string FormTransitName(
+      const Maneuver& maneuver,
+      const std::vector<std::string>& empty_transit_name_labels);
 
   /////////////////////////////////////////////////////////////////////////////
   // TODO make virtual


### PR DESCRIPTION
Added empty_transit_name_labels to the following phrase sets:

- transit
- transit_verbal
- transit_remain_on
- transit_remain_on_verbal
- transit_transfer
- transit_transfer_verbal

Added some example_phrases too.

@mormegil-cz could you please update cs-CZ.json
@kevinkreiser could you please update de-DE.json

Closes #269 