### PR TITLE
Added Czech localization for new empty_transit_name_labels

### DIFF
--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -792,11 +792,11 @@
         "0": "Nastupte na <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Nastupte na <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["tramvaj", "metro", "vlak", "autobus", "přívoz", "lanovku", "lanovku", "lanovku"],
       "transit_stop_count_labels": ["zastávka", "zastávek"],
       "example_phrases": {
-        "0": ["Nastupte na New Haven. (1 zastávka)", "Take the metro. (2 stops)", "Take the bus. (12 stops)"],
-        "1": ["Nastupte na F směr JAMAICA - 179 ST. (10 zastávek)", "Take the ferry toward Staten Island. (1 stop)"]
+        "0": ["Nastupte na New Haven. (1 zastávka)", "Nastupte na metro. (2 zastávek)", "Nastupte na autobus. (12 zastávek)"],
+        "1": ["Nastupte na F směr JAMAICA - 179 ST. (10 zastávek)", "Nastupte na přívoz směr Staten Island. (1 zastávka)"]
       }
     },
     "transit_verbal": {
@@ -804,7 +804,7 @@
         "0": "Nastupte na <TRANSIT_NAME>.",
         "1": "Nastupte na <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>."
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["tramvaj", "metro", "vlak", "autobus", "přívoz", "lanovku", "lanovku", "lanovku"],
       "example_phrases": {
         "0": ["Nastupte na New Haven."],
         "1": ["Nastupte na F směr JAMAICA - 179 ST."]
@@ -815,10 +815,10 @@
         "0": "Zůstaňte v <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Zůstaňte v <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["tramvaji", "metru", "vlaku", "autobusu", "přívozu", "lanovce", "lanovce", "lanovce"],
       "transit_stop_count_labels": ["zastávka", "zastávek"],
       "example_phrases": {
-        "0": ["Zůstaňte v New Haven. (1 zastávka)", "Remain on the train. (3 stops)"],
+        "0": ["Zůstaňte v New Haven. (1 zastávka)", "Zůstaňte v vlaku. (3 zastávek)"],
         "1": ["Zůstaňte v F směr JAMAICA - 179 ST. (10 zastávek)"]
       }
     },
@@ -827,7 +827,7 @@
         "0": "Zůstaňte v <TRANSIT_NAME>.",
         "1": "Zůstaňte v <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>."
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["tramvaji", "metru", "vlaku", "autobusu", "přívozu", "lanovce", "lanovce", "lanovce"],
       "example_phrases": {
         "0": ["Zůstaňte v New Haven."],
         "1": ["Zůstaňte v F směr JAMAICA - 179 ST."]
@@ -838,10 +838,10 @@
         "0": "Přestupte na <TRANSIT_NAME>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
         "1": "Přestupte na <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["tramvaj", "metro", "vlak", "autobus", "přívoz", "lanovku", "lanovku", "lanovku"],
       "transit_stop_count_labels": ["zastávka", "zastávek"],
       "example_phrases": {
-        "0": ["Přestupte na New Haven. (1 zastávka)", "Transfer to take the tram. (4 stops)"],
+        "0": ["Přestupte na New Haven. (1 zastávka)", "Přestupte na tramvaj. (4 zastávek)"],
         "1": ["Přestupte na F směr JAMAICA - 179 ST. (10 zastávek)"]
       }
     },
@@ -850,7 +850,7 @@
         "0": "Přestupte na <TRANSIT_NAME>.",
         "1": "Přestupte na <TRANSIT_NAME> směr <TRANSIT_HEADSIGN>."
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["tramvaj", "metro", "vlak", "autobus", "přívoz", "lanovku", "lanovku", "lanovku"],
       "example_phrases": {
         "0": ["Přestupte na New Haven."],
         "1": ["Přestupte na F směr JAMAICA - 179 ST."]


### PR DESCRIPTION
Translated cs-CZ localization for the new messages introduced in #289.