### PR TITLE
german updates

### DIFF
--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -789,10 +789,10 @@
     },
     "transit": {
       "phrases": {
-        "0": "Mit der Linie <TRANSIT_NAME> fahren. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
-        "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> fahren. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
+        "0": "Mit <TRANSIT_NAME> fahren. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
+        "1": "Mit <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> fahren. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["Straßenbahn", "U-Bahn", "Zug", "Bus", "Fähre", "Kabelbahn", "Luftseilbahn", "Standseilbahn"],
       "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
       "example_phrases": {
         "0": ["Take the New Haven. (1 stop)", "Take the metro. (2 stops)", "Take the bus. (12 stops)"],
@@ -801,10 +801,10 @@
     },
     "transit_verbal": {
       "phrases": {
-        "0": "Mit der Linie <TRANSIT_NAME> fahren.",
-        "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> fahren."
+        "0": "Mit <TRANSIT_NAME> fahren.",
+        "1": "Mit <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> fahren."
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["Straßenbahn", "U-Bahn", "Zug", "Bus", "Fähre", "Kabelbahn", "Luftseilbahn", "Standseilbahn"],
       "example_phrases": {
         "0": ["Take the New Haven."],
         "1": ["Take the F toward JAMAICA - 179 ST."]
@@ -812,10 +812,10 @@
     },
     "transit_remain_on": {
       "phrases": {
-        "0": "Mit der Linie <TRANSIT_NAME> weiter. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
-        "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> weiter. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
+        "0": "Mit <TRANSIT_NAME> weiter. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
+        "1": "Mit <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> weiter. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["Straßenbahn", "U-Bahn", "Zug", "Bus", "Fähre", "Kabelbahn", "Luftseilbahn", "Standseilbahn"],
       "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
       "example_phrases": {
         "0": ["Remain on the New Haven. (1 stop)", "Remain on the train. (3 stops)"],
@@ -824,10 +824,10 @@
     },
     "transit_remain_on_verbal": {
       "phrases": {
-        "0": "Mit der Linie <TRANSIT_NAME> weiter.",
-        "1": "Mit der Linie <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> weiter."
+        "0": "Mit <TRANSIT_NAME> weiter fahren.",
+        "1": "Mit <TRANSIT_NAME> Richtung <TRANSIT_HEADSIGN> weiter fahren."
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["Straßenbahn", "U-Bahn", "Zug", "Bus", "Fähre", "Kabelbahn", "Luftseilbahn", "Standseilbahn"],
       "example_phrases": {
         "0": ["Remain on the New Haven."],
         "1": ["Remain on the F toward JAMAICA - 179 ST."]
@@ -835,10 +835,10 @@
     },
     "transit_transfer": {
       "phrases": {
-        "0": "Zur Linie <TRANSIT_NAME> umsteigen. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
-        "1": "Zur Linie <TRANSIT_NAME> Richtugn <TRANSIT_HEADSIGN> umsteigen. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
+        "0": "Zu <TRANSIT_NAME> umsteigen. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)",
+        "1": "Zu <TRANSIT_NAME> Richtugn <TRANSIT_HEADSIGN> umsteigen. (<TRANSIT_STOP_COUNT> <TRANSIT_STOP_COUNT_LABEL>)"
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["Straßenbahn", "U-Bahn", "Zug", "Bus", "Fähre", "Kabelbahn", "Luftseilbahn", "Standseilbahn"],
       "transit_stop_count_labels": ["Haltestelle", "Haltestellen"],
       "example_phrases": {
         "0": ["Transfer to take the New Haven. (1 stop)", "Transfer to take the tram. (4 stops)"],
@@ -847,10 +847,10 @@
     },
     "transit_transfer_verbal": {
       "phrases": {
-        "0": "Zur Linie <TRANSIT_NAME> umsteigen.",
-        "1": "Zur Linie <TRANSIT_NAME> Richtugn <TRANSIT_HEADSIGN> umsteigen."
+        "0": "Zu <TRANSIT_NAME> umsteigen.",
+        "1": "Zu <TRANSIT_NAME> Richtugn <TRANSIT_HEADSIGN> umsteigen."
       },
-      "empty_transit_name_labels": ["tram", "metro", "train", "bus", "ferry", "cable car", "gondola", "funicular"],
+      "empty_transit_name_labels": ["Straßenbahn", "U-Bahn", "Zug", "Bus", "Fähre", "Kabelbahn", "Luftseilbahn", "Standseilbahn"],
       "example_phrases": {
         "0": ["Transfer to take the New Haven."],
         "1": ["Transfer to take the F toward JAMAICA - 179 ST."]


### PR DESCRIPTION
basically because we cant gaurantee a named line will be there we have to do the sucky compromise of taking out the word for `line`. this reads very clunky but there is no way to do it without adding more phrases.

actually that might be a good strategy for all of this stuff. have the phrases once with the replacement from the data, but then have them again with the replacement from the replacements list. decoupling them would allow for much better sounding translations.