### PR TITLE
Combine unnamed straight maneuvers

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -116,7 +116,7 @@ std::list<Maneuver> ManeuversBuilder::Build() {
   std::string units = (directions_options_.units() == valhalla::odin::DirectionsOptions::kKilometers) ? "kilometers" : "miles";
   LOG_DEBUG(
       (boost::format(
-              "ROUTE_REQUEST|-j '{\"locations\":[{\"lat\":%1$.6f,\"lon\":%2$.6f,\"street\":\"%3%\"},{\"lat\":%4$.6f,\"lon\":%5$.6f,\"street\":\"%6%\"}],\"costing\":\"auto\",\"directions_options\":{\"units\":\"%7%\"}}' --config ../conf/valhalla.json")
+              "ROUTE_REQUEST|-j '{\"locations\":[{\"lat\":%1$.6f,\"lon\":%2$.6f,\"street\":\"%3%\"},{\"lat\":%4$.6f,\"lon\":%5$.6f,\"street\":\"%6%\"}],\"costing\":\"auto\",\"directions_options\":{\"units\":\"%7%\"}}'")
           % orig.ll().lat() % orig.ll().lng() % first_name
           % dest.ll().lat() % dest.ll().lng() % last_name
           % units).str());

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -381,6 +381,21 @@ void ManeuversBuilder::Combine(std::list<Maneuver>& maneuvers) {
         next_man = CombineSameNameStraightManeuver(maneuvers, curr_man,
                                                    next_man);
         maneuvers_have_been_combined = true;
+      }
+      // Combine unnamed straight maneuvers
+      else if ((next_man->begin_relative_direction()
+          == Maneuver::RelativeDirection::kKeepStraight)
+          && !curr_man->HasStreetNames() && !next_man->HasStreetNames()
+          && !curr_man->IsTransit() && !next_man->IsTransit()
+          && (next_man_begin_edge && !next_man_begin_edge->turn_channel())
+          && !next_man->internal_intersection() && !curr_man->ramp()
+          && !next_man->ramp() && !curr_man->roundabout()
+          && !next_man->roundabout()) {
+
+        LOG_TRACE("+++ Combine: unnamed straight maneuvers +++");
+        next_man = CombineSameNameStraightManeuver(maneuvers, curr_man,
+                                                   next_man);
+        maneuvers_have_been_combined = true;
       } else {
         LOG_TRACE("+++ Do Not Combine +++");
         // Update with no combine


### PR DESCRIPTION
Closes #165 
Closes #155 

For this example route:
http://www.openstreetmap.org/directions?engine=mapzen_car&route=28.5669%2C77.2078%3B28.6168%2C77.3647#map=12/28.5906/77.2856

Here is the before and after comparison:
```
BEFORE
17: Continue. | 1.6 mi
18: Continue. | 0.4 mi
19: Continue. | 0.8 mi
AFTER
17: Continue. | 2.8 mi

BEFORE
23: Continue. | 0.2 mi
24: Continue. | 0.1 mi
25: Continue. | 0.4 mi
26: Turn left. | 0.3 mi
27: Bear right. | 0.2 mi
28: Turn right. | 0.1 mi
29: Bear left. | 0.0 mi
30: Your destination is on the left. | 0.0 mi
AFTER
21: Turn left. | 0.4 mi
22: Turn right. | 0.1 mi
23: Your destination is on the left. | 0.0 mi
```
 Removed 7 unneeded maneuvers from the above example