### PR TITLE
Updated intersecting forward edge logic

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1807,7 +1807,7 @@ bool ManeuversBuilder::IsIntersectingForwardEdge(
                                        curr_edge->begin_heading());
 
   if (node->HasIntersectingEdges() && !node->motorway_junction()
-      && !node->fork() && !curr_edge->IsHighway()) {
+      && !node->fork() && !(curr_edge->IsHighway() && prev_edge->IsHighway())) {
     // if path edge is not forward
     // and forward traversable intersecting edge exists
     // then return true


### PR DESCRIPTION
Both the previous edge and the current edge must be marked as highways in order to ignore within the intersecting forward edge method.
Closes #292 

```
BEFORE
1: Drive southwest on Church Avenue/NY 27. Continue on NY 27 West. | 0.1 mi
2: You have arrived at NY 27 West. | 0.0 mi
AFTER
1: Drive southwest on Church Avenue/NY 27. | 0.0 mi
2: Turn right onto NY 27 West/Prospect Expressway. | 0.1 mi
3: You have arrived at NY 27 West. | 0.0 mi
```
