### PR TITLE
only generate locales on linux

### DIFF
--- a/locales/make_locales.sh
+++ b/locales/make_locales.sh
@@ -2,9 +2,11 @@
 set -e
 
 #install locales locally for testing
-for loc in $(grep -F posix_locale *.json | sed -e "s/.*locale[^a-z^A-Z]\+//g" -e "s/[^a-z^A-Z^0-9^.^_]\+//g"); do
-	localedef -i ${loc%.*} -f UTF-8 ./${loc}
-done
+if [[ "$OSTYPE" == "linux"* ]]; then
+	for loc in $(grep -F posix_locale *.json | sed -e "s/.*locale[^a-z^A-Z]\+//g" -e "s/[^a-z^A-Z^0-9^.^_]\+//g"); do
+		localedef -i ${loc%.*} -f UTF-8 ./${loc}
+	done
+fi
 
 #throw all the text into one big header
 code=


### PR DESCRIPTION
`localedef` syntax is different on OSX, looks like this is used for debugging only, so just skipping it on darwin

ps. not messing with `sed` this time - easier to install `gsed` locally, otherwise expressions become too gnarly :)