### PR TITLE
allow language aliases to satisfy different naming schemes

### DIFF
--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -1,5 +1,6 @@
 {
   "posix_locale": "cs_CZ.UTF-8",
+  "aliases": ["cs"],
   "instructions": {
     "start": {
       "phrases": {

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -1,5 +1,6 @@
 {
   "posix_locale": "de_DE.UTF-8",
+  "aliases": ["de"],
   "instructions": {
     "start": {
       "phrases": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1,5 +1,6 @@
 {
   "posix_locale": "en_US.UTF-8",
+  "aliases": ["en"],
   "instructions": {
     "start": {
       "phrases": {

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -1,5 +1,6 @@
 {
   "posix_locale": "fr_FR.UTF-8",
+  "aliases": ["fr"],
   "instructions": {
     "start": {
       "phrases": {

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -1,5 +1,6 @@
 {
   "posix_locale": "it_IT.UTF-8",
+  "aliases": ["it"],
   "instructions": {
     "start": {
       "phrases": {

--- a/src/odin/narrative_builder_factory.cc
+++ b/src/odin/narrative_builder_factory.cc
@@ -28,12 +28,12 @@ std::unique_ptr<NarrativeBuilder> NarrativeBuilderFactory::Create(
   // language then add logic here and return derived NarrativeBuilder
   if (directions_options.language() == "cs-CZ") {
     return midgard::make_unique<NarrativeBuilder_csCZ>(
-        directions_options, trip_path, phrase_dictionary->second);
+        directions_options, trip_path, *phrase_dictionary->second);
   }
 
   // otherwise just return pointer to NarrativeBuilder
   return midgard::make_unique<NarrativeBuilder>(directions_options, trip_path,
-                                                phrase_dictionary->second);
+                                                *phrase_dictionary->second);
 }
 
 }

--- a/test/narrative_dictionary.cc
+++ b/test/narrative_dictionary.cc
@@ -295,7 +295,7 @@ const NarrativeDictionary& GetNarrativeDictionary(const std::string& lang_tag) {
     throw std::runtime_error("Invalid language tag.");
   }
 
-  return phrase_dictionary->second;
+  return *phrase_dictionary->second;
 }
 
 void validate(const std::string& test_target, const std::string& expected) {

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -62,7 +62,7 @@ const NarrativeDictionary& GetNarrativeDictionary(
     throw std::runtime_error("Invalid language tag.");
   }
 
-  return phrase_dictionary->second;
+  return *phrase_dictionary->second;
 }
 
 void PopulateManeuver(

--- a/test/util_odin.cc
+++ b/test/util_odin.cc
@@ -190,8 +190,8 @@ namespace {
 int main() {
   test::suite suite("util");
 
-  //suite.test(TEST_CASE(test_supported_locales));
-  //suite.test(TEST_CASE(test_get_locales));
+  suite.test(TEST_CASE(test_supported_locales));
+  suite.test(TEST_CASE(test_get_locales));
   suite.test(TEST_CASE(test_time));
   suite.test(TEST_CASE(test_date));
 

--- a/valhalla/odin/util.h
+++ b/valhalla/odin/util.h
@@ -52,7 +52,7 @@ std::string get_localized_date(const std::string& date_time,
  *
  * @return the map of locales to NarrativeDictionaries
  */
-using locales_singleton_t = std::unordered_map<std::string, NarrativeDictionary>;
+using locales_singleton_t = std::unordered_map<std::string, std::shared_ptr<NarrativeDictionary> >;
 const locales_singleton_t& get_locales();
 
 /**


### PR DESCRIPTION
this allows requests to specify language aliases instead of the `bcp47` codes we've been adhering too. it does so by adding an `aliases` section to the json of a particular file. this means we can quickly look up a language and we dont have to duplicate it or the object its parsed into (`shared_ptr`). it also allows us to match many different standards (whatever those may be). in fact maybe we should put the 3 letter codes in here as well?

another important thing here is that if a language file cant load, because the json is broken or an alias clashes with another language file, we will throw an exception that is not handled and abort. this makes sure that our tests fail when they should. before we were doing a `LOG_WARN` when this was happening which could technically leave us with no actual languages loaded.

fixes #331 

@dgearhart @mormegil-cz @tomhughes what do you all think?