### PR TITLE
For portability, use cd foo && cd - instead of pushd foo && popd.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,7 @@ src/proto/%.pb.cc: proto/%.proto
 
 #turn locales json into strings we can load
 src/odin/locales.h: locales/*.json
-	-pushd locales && ./make_locales.sh *.json > ../src/odin/locales.h && popd
+	-cd locales && ./make_locales.sh *.json > ../src/odin/locales.h && cd -
 
 BUILT_SOURCES = $(patsubst %.proto,src/%.pb.cc,$(PROTO_FILES)) src/odin/locales.h
 nodist_libvalhalla_odin_la_SOURCES = $(patsubst %.proto,src/%.pb.cc,$(PROTO_FILES)) src/odin/locales.h


### PR DESCRIPTION
pushd/popd is available in bash, but not in POSIX. Some shells, like OpenBSD’s ksh, don’t provide them.