### PR TITLE
install test locales after code generation

### DIFF
--- a/locales/make_locales.sh
+++ b/locales/make_locales.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -e
 
-#install locales locally for testing
-for loc in $(jq ".posix_locale" *.json | sed -e 's/"//g'); do
-	localedef -i "${loc%.*}" -f "${loc##*.}" "./${loc}"
-done
-
 #throw all the text into one big header
 code=
 for f in "${@}"; do
@@ -26,3 +21,8 @@ echo "${code}"
 echo "const std::unordered_map<std::string, std::string> locales_json = {";
 echo "  ${map}"
 echo "};";
+
+#install locales locally for testing
+for loc in $(jq ".posix_locale" *.json | sed -e 's/"//g'); do
+	localedef -i "${loc%.*}" -f "${loc##*.}" "./${loc}"
+done


### PR DESCRIPTION
`localedef` does not work on OSX, so run it after header generation (otherwise header is not generated due to `set -e`)