### PR TITLE
Updated the 'enter roundabout' verbal alert to have spoke count

### DIFF
--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -2178,15 +2178,27 @@ std::string NarrativeBuilder::FormEnterRoundaboutInstruction(Maneuver& maneuver)
 std::string NarrativeBuilder::FormVerbalAlertEnterRoundaboutInstruction(
     Maneuver& maneuver, uint32_t element_max_count, const std::string& delim) {
   // "0": "Enter the roundabout.",
+  // "1": "Enter the roundabout and take the <ORDINAL_VALUE> exit."
 
   std::string instruction;
   instruction.reserve(kInstructionInitialCapacity);
 
   // Determine which phrase to use
   uint8_t phrase_id = 0;
+  std::string ordinal_value;
+  if ((maneuver.roundabout_exit_count() >= kRoundaboutExitCountLowerBound)
+      && (maneuver.roundabout_exit_count() <= kRoundaboutExitCountUpperBound)) {
+    phrase_id = 1;
+    // Set ordinal_value
+    ordinal_value = dictionary_.enter_roundabout_verbal_subset.ordinal_values.at(
+        maneuver.roundabout_exit_count()-1);
+  }
 
   // Set instruction to the determined tagged phrase
   instruction = dictionary_.enter_roundabout_verbal_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kOrdinalValueTag, ordinal_value);
 
   return instruction;
 

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -5774,7 +5774,7 @@ void TestBuildEnterRoundabout_0_miles_en_US() {
 ///////////////////////////////////////////////////////////////////////////////
 // FormEnterRoundaboutInstruction
 // "1": "Enter the roundabout and take the <ORDINAL_VALUE> exit."
-// "0": "Enter the roundabout.",
+// "1": "Enter the roundabout and take the <ORDINAL_VALUE> exit."
 // "1": "Enter the roundabout and take the <ORDINAL_VALUE> exit."
 void TestBuildEnterRoundabout_1_miles_en_US() {
   std::string country_code = "US";
@@ -5802,7 +5802,7 @@ void TestBuildEnterRoundabout_1_miles_en_US() {
     SetExpectedManeuverInstructions(
         expected_maneuvers,
         "Enter the roundabout and take the " + ordinal_value + " exit.",
-        "Enter the roundabout.",
+        "Enter the roundabout and take the " + ordinal_value + " exit.",
         "Enter the roundabout and take the " + ordinal_value + " exit.", "");
 
     TryBuild(directions_options, maneuvers, expected_maneuvers);


### PR DESCRIPTION
Closes #351 
``` Diff
< BEFORE
<    VERBAL_ALERT: Enter the roundabout.

> AFTER
>    VERBAL_ALERT: Enter the roundabout and take the 3rd exit.
```
![screenshot from 2016-08-26 16 04 19](https://cloud.githubusercontent.com/assets/7515853/18018811/06b2ac04-6ba7-11e6-91ab-3c289bb65c89.png)


``` Diff
< BEFORE
<    VERBAL_ALERT: Enter the roundabout.

> AFTER
>    VERBAL_ALERT: Enter the roundabout and take the 2nd exit.
```
![screenshot from 2016-08-26 16 04 57](https://cloud.githubusercontent.com/assets/7515853/18018819/10924612-6ba7-11e6-9f92-c729f7c302c8.png)
