### PR TITLE
combine straight turn channel

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -2027,6 +2027,12 @@ bool ManeuversBuilder::IsTurnChannelManeuverCombinable(
       return true;
     }
 
+    // Process simple straight "turn channel"
+    if ((curr_man->begin_relative_direction() == Maneuver::RelativeDirection::kKeepStraight)
+        && (new_turn_type == Turn::Type::kStraight)) {
+      return true;
+    }
+
   }
   return false;
 }


### PR DESCRIPTION
It possible to get a straight "turn channel", if link reclassification is disabled and link_type is explicitly set to "slip"