### PR TITLE
Fixed missing turn by updating the forward intersecting edge logic.

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1839,11 +1839,10 @@ bool ManeuversBuilder::IsIntersectingForwardEdge(
   if (node->HasIntersectingEdges() && !node->motorway_junction()
       && !node->fork() && !(curr_edge->IsHighway() && prev_edge->IsHighway())) {
     // if path edge is not forward
-    // and forward traversable intersecting edge exists
+    // and forward intersecting edge exists
     // then return true
     if (!curr_edge->IsForward(turn_degree)
-        && node->HasForwardTraversableIntersectingEdge(
-            prev_edge->end_heading(), prev_edge->travel_mode())) {
+        && node->HasFowardIntersectingEdge(prev_edge->end_heading())) {
       return true;
     }
     // if path edge is forward


### PR DESCRIPTION
@randymeech - fixed, thanks for submitting

``` Diff
< BEFORE
< 4: Turn left onto East Orange Street. | 0.5 mi

> AFTER
> 4: Turn right onto North Broad Street/PA 462 West. | 0.1 mi
> 5: Turn left onto East Orange Street. | 0.5 mi
```
![screenshot from 2016-11-08 15 33 29](https://cloud.githubusercontent.com/assets/7515853/20117038/d29ad440-a5cc-11e6-8aa5-02b5b3c05da0.png)
